### PR TITLE
replace apns token with fcmToken

### DIFF
--- a/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Util/AppHelper.swift
+++ b/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Util/AppHelper.swift
@@ -32,7 +32,7 @@ class AppHelper {
     }
     
     static func getDevicePlatform() -> String {
-        return UIDevice.current.systemName
+        return UIDevice.current.systemName.lowercased()
     }
     
     static func getiOSVersion() -> String {


### PR DESCRIPTION
현재 apns token이 서버로 전송되고 있는데, 실제로 푸시메시지를 보낼 때 저희 인프라 상 fcmToken이 더 편하여 이렇게 수정합니다!
번거롭게 해드려 죄송합니다.
