### PR TITLE
change open URL function in push notification click handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+NotiflyTestApp/NotiflyTestApp/GoogleService-Info.plist
 ### Xcode ###
 ## User settings
 xcuserdata/

--- a/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Notifications/NotificationsManager.swift
+++ b/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Notifications/NotificationsManager.swift
@@ -112,7 +112,7 @@ class NotificationsManager: NSObject {
         Logger.info("Received Push Notificatiob with content: \(content)")
         if let urlString = content.userInfo["url"] as? String,
             let url = URL(string: urlString) {
-            presentWebViewForURL(url: url)
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
         }
         UIApplication.shared.applicationIconBadgeNumber = 0
         completion()


### PR DESCRIPTION
본 PR의 핸들러는 푸시알림 클릭 핸들러이고 in-app message 핸들러는 다른 PR에서 따로 만드려 합니다!
사용하고 계신 presentWebViewForURL(url: url) 함수는 아마도 인웹브라우저로 url을 이용해 웹뷰를 띄우는 함수 같아 보여 다음과 같이 수정해보았습니다! 아마 이렇게 구현하신 이유가 in-app message용이 아닐까 생각했습니다!

푸시알림을 클릭했을 때
url 에 https://www.naver.com같이 웹사이트url이 있을 수도 있고 앱 deeplink가 있을 수 있어서 다음 함수로 변경합니다!
`
UIApplication.shared.open(url, options: [:], completionHandler: nil)
`

제가 swift가 처음이라 react native 에서 사용하고 있는 Linking.openURL과 똑같은 swift함수를 챗 GPT에게 물어보니 이 함수를 사용하라 하여 썼더니 푸시알림을 클릭했을 때, naver.com같은 url이 인웹브라우저가 아닌 외부 browser로 잘 열리는 것을 확인했습니다!

TODO: App Deeplink 테스트