### PR TITLE
fix: Defending against crashes due to concurrency issues in the process of updating the users event data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,4 +42,8 @@
 
 # 1.7.0
 
-- Chore: Add Privacy Manifest 
+- Chore: Add Privacy Manifest
+
+# 1.7.1
+
+- Fix: Defending against crashes due to concurrency issues in the process of updating the user's event data.

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastrucutres/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastrucutres/InAppMessage/UserStateManager.swift
@@ -199,13 +199,18 @@ class UserStateManager {
 
     /* update client state */
     func incrementEic(eventName: String, eventParams: [String: Any]?, segmentationEventParamKeys: [String]?) {
-        let dt = NotiflyHelper.getCurrentDate()
-        let eicID = EventIntermediateCount.generateId(eventName: eventName, eventParams: eventParams, segmentationEventParamKeys: segmentationEventParamKeys, dt: dt)
-        if var eic = eventData.eventCounts[eicID] {
-            eic.addCount(count: 1)
-            eventData.eventCounts[eicID] = eic
-        } else {
-            eventData.eventCounts[eicID] = EventIntermediateCount(name: eventName, dt: dt, count: 1, eventParams: eventParams ?? [:])
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            let dt = NotiflyHelper.getCurrentDate()
+            let eicID = EventIntermediateCount.generateId(eventName: eventName, eventParams: eventParams, segmentationEventParamKeys: segmentationEventParamKeys, dt: dt)
+            DispatchQueue.main.async {
+                if var eic = self.eventData.eventCounts[eicID] {
+                    eic.addCount(count: 1)
+                    self.eventData.eventCounts[eicID] = eic
+                } else {
+                    self.eventData.eventCounts[eicID] = EventIntermediateCount(name: eventName, dt: dt, count: 1, eventParams: eventParams ?? [:])
+                }
+            }
         }
     }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflyConstant {
-    static let sdkVersion: String = "1.7.0"
+    static let sdkVersion: String = "1.7.1"
     static let iosPlatform: String = "ios"
     enum EndPoint {
         static let trackEventEndPoint = "https://12lnng07q2.execute-api.ap-northeast-2.amazonaws.com/prod/records"

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '1.7.0'
+  s.version          = '1.7.1'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 1.7.0
+  NOTIFLY iOS SDK : 1.7.1
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary
incrementEic함수가 동시성 문제로 크래시를 유발할 잠재 원인을 main queue로 처리하도록 함으로써 크래시를 방지합니다.

## Describe your changes

## Issue ticket number and link
