### PR TITLE
fix: renewal user state manager to access shared resources with serial queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,8 @@
 # 1.10.1
 
 - Fix: Fix main-thread checker warning
+
+# 1.11.0
+
+- Chore: Change UserState Management Logic using access queue.
+- Chore: Replace user state lock with NotiflyAsyncWorker (Semaphore)

--- a/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/AppDelegate.swift
+++ b/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/AppDelegate.swift
@@ -24,7 +24,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         FirebaseApp.configure()
+
         Notifly.initialize(projectId: TestConstant.projectID, username: TestConstant.username, password: TestConstant.password)
+        // for i in 0 ..< 100 {
+        //     Notifly.setUserId(userId: nil)
+        //     Notifly.trackEvent(eventName: "app_opened_unregistered")
+        //     Notifly.setUserId(userId: "kds\(i)")
+        //     Notifly.trackEvent(eventName: "app_opened")
+        //     print("\(i) / 100 completed.")
+        // }
 
         UNUserNotificationCenter.current().delegate = self
         return true

--- a/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/SceneDelegate.swift
+++ b/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/SceneDelegate.swift
@@ -8,11 +8,9 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
     var window: UIWindow?
 
-
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
@@ -21,35 +19,35 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) {
+    func sceneDidDisconnect(_: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
     }
 
-    func sceneDidBecomeActive(_ scene: UIScene) {
+    func sceneDidBecomeActive(_: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
     }
 
-    func sceneWillResignActive(_ scene: UIScene) {
+    func sceneWillResignActive(_: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
     }
 
-    func sceneWillEnterForeground(_ scene: UIScene) {
+    func sceneWillEnterForeground(_: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
     }
 
-    func sceneDidEnterBackground(_ scene: UIScene) {
+    func sceneDidEnterBackground(_: UIScene) {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
 
-    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    func scene(_: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         guard let url = URLContexts.first?.url else {
             return
         }
@@ -68,7 +66,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
         print("page이름 = \(name)")
-
         switch name {
         case "notification":
             let notificationVC = PushNotificationTestViewController()
@@ -107,6 +104,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
     }
-
 }
-

--- a/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/TrackingTestViewController.swift
+++ b/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/TrackingTestViewController.swift
@@ -115,19 +115,19 @@ class TrackingTestViewController: UIViewController {
 
         responsePayloadTextView.text = "N/A"
 
-        // let wrongGroup = DispatchGroup()
-        // let wrongQueue = DispatchQueue(label: "WrongQueue")
-        // for i in 0 ..< 1000 {
-        //     wrongGroup.enter()
-        //     wrongQueue.async {
-        //         Notifly.setUserId(userId: nil)
-        //         Notifly.setUserId(userId: "WrongUserID\(i)")
-        //         Notifly.trackEvent(eventName: "WrongEvent\(i)")
-        //         Notifly.setUserId(userId: nil)
-        //         wrongGroup.leave()
-        //     }
-        // }
-        // wrongGroup.wait()
+        let wrongGroup = DispatchGroup()
+        let wrongQueue = DispatchQueue(label: "WrongQueue")
+        for i in 0 ..< 30 {
+            wrongGroup.enter()
+            wrongQueue.async {
+                Notifly.setUserId(userId: nil)
+                Notifly.setUserId(userId: "WrongUserID\(i)")
+                Notifly.trackEvent(eventName: "WrongEvent\(i)")
+                Notifly.setUserId(userId: nil)
+                wrongGroup.leave()
+            }
+        }
+        wrongGroup.wait()
 
         try? Notifly.trackEvent(eventName: eventName,
                                 eventParams: customEventParams,

--- a/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/TrackingTestViewController.swift
+++ b/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/TrackingTestViewController.swift
@@ -115,19 +115,19 @@ class TrackingTestViewController: UIViewController {
 
         responsePayloadTextView.text = "N/A"
 
-        let wrongGroup = DispatchGroup()
-        let wrongQueue = DispatchQueue(label: "WrongQueue")
-        for i in 0 ..< 30 {
-            wrongGroup.enter()
-            wrongQueue.async {
-                Notifly.setUserId(userId: nil)
-                Notifly.setUserId(userId: "WrongUserID\(i)")
-                Notifly.trackEvent(eventName: "WrongEvent\(i)")
-                Notifly.setUserId(userId: nil)
-                wrongGroup.leave()
-            }
-        }
-        wrongGroup.wait()
+        // let wrongGroup = DispatchGroup()
+        // let wrongQueue = DispatchQueue(label: "WrongQueue")
+        // for i in 0 ..< 30 {
+        //     wrongGroup.enter()
+        //     wrongQueue.async {
+        //         Notifly.setUserId(userId: nil)
+        //         Notifly.setUserId(userId: "WrongUserID\(i)")
+        //         Notifly.trackEvent(eventName: "WrongEvent\(i)")
+        //         Notifly.setUserId(userId: nil)
+        //         wrongGroup.leave()
+        //     }
+        // }
+        // wrongGroup.wait()
 
         try? Notifly.trackEvent(eventName: eventName,
                                 eventParams: customEventParams,

--- a/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/TrackingTestViewController.swift
+++ b/NotiflyTestApp/NotiflyTestApp/SourceCodes/UI/TrackingTestViewController.swift
@@ -3,7 +3,6 @@ import Combine
 import UIKit
 
 class TrackingTestViewController: UIViewController {
-
     // MARK: UI Components
 
     let stackView = UIStackView()
@@ -34,24 +33,24 @@ class TrackingTestViewController: UIViewController {
         encoder.outputFormatting = .prettyPrinted
 
         try? Notifly.main.trackingManager.eventRequestPayloadPublisher
-        .encode(encoder: encoder)
-        .map {
-            String(data: $0, encoding: .utf8) ?? "Encoding Error"
-        }
-        .catch {
-            Just("Failed to encode Event payload with error: \($0)")
-        }
-        .receive(on: RunLoop.main)
-        .assign(to: \.text, on: requestPayloadTextView)
-        .store(in: &cancellables)
+            .encode(encoder: encoder)
+            .map {
+                String(data: $0, encoding: .utf8) ?? "Encoding Error"
+            }
+            .catch {
+                Just("Failed to encode Event payload with error: \($0)")
+            }
+            .receive(on: RunLoop.main)
+            .assign(to: \.text, on: requestPayloadTextView)
+            .store(in: &cancellables)
 
         // Inspect Response Payload.
         try? Notifly.main.trackingManager.eventRequestResponsePublisher
-        .receive(on: RunLoop.main)
-        .sink { [weak self] resultingString in
-            self?.responsePayloadTextView.text = resultingString
-        }
-        .store(in: &cancellables)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] resultingString in
+                self?.responsePayloadTextView.text = resultingString
+            }
+            .store(in: &cancellables)
     }
 
     private func setupUI() {
@@ -74,11 +73,11 @@ class TrackingTestViewController: UIViewController {
         view.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-                                        view.safeAreaLayoutGuide.topAnchor.constraint(equalTo: stackView.topAnchor),
-                                        view.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-                                        view.safeAreaLayoutGuide.leftAnchor.constraint(equalTo: stackView.leftAnchor, constant: -12),
-                                        view.safeAreaLayoutGuide.rightAnchor.constraint(equalTo: stackView.rightAnchor, constant: 12)
-                                    ])
+            view.safeAreaLayoutGuide.topAnchor.constraint(equalTo: stackView.topAnchor),
+            view.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
+            view.safeAreaLayoutGuide.leftAnchor.constraint(equalTo: stackView.leftAnchor, constant: -12),
+            view.safeAreaLayoutGuide.rightAnchor.constraint(equalTo: stackView.rightAnchor, constant: 12),
+        ])
 
         // StackView Config
         stackView.axis = .vertical
@@ -114,22 +113,34 @@ class TrackingTestViewController: UIViewController {
             .split(separator: ",")
             .map(String.init)
 
-        requestPayloadTextView.text = "Queued the tracking event. Queued tracking events are fired within \(try? Notifly.main.trackingManager.trackingFiringInterval) seconds of interval."
         responsePayloadTextView.text = "N/A"
 
-        // Fire Tracking
+        // let wrongGroup = DispatchGroup()
+        // let wrongQueue = DispatchQueue(label: "WrongQueue")
+        // for i in 0 ..< 1000 {
+        //     wrongGroup.enter()
+        //     wrongQueue.async {
+        //         Notifly.setUserId(userId: nil)
+        //         Notifly.setUserId(userId: "WrongUserID\(i)")
+        //         Notifly.trackEvent(eventName: "WrongEvent\(i)")
+        //         Notifly.setUserId(userId: nil)
+        //         wrongGroup.leave()
+        //     }
+        // }
+        // wrongGroup.wait()
+
         try? Notifly.trackEvent(eventName: eventName,
                                 eventParams: customEventParams,
                                 segmentationEventParamKeys: segmentationEventParamKeys)
     }
 
     @objc
-    private func customEventParmsBtnTapped(sender: UIButton) {
+    private func customEventParmsBtnTapped(sender _: UIButton) {
         presentCustomEventParamsVS()
     }
 
     @objc
-    private func submitBtnTapped(sender: UIButton) {
+    private func submitBtnTapped(sender _: UIButton) {
         submitTrackingEventWithCurrentInputs()
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */; };
 		672E7DF329EFA50400B3E9F2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 672E7DF229EFA50400B3E9F2 /* FirebaseMessaging */; };
 		673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */; };
 		673F0E8B29EBA7D200814217 /* notifly_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */; };
@@ -54,6 +55,7 @@
 
 /* Begin PBXFileReference section */
 		2B91499B2BDA3C3A0066CDD0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncWorker.swift; sourceTree = "<group>"; };
 		673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = notifly_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = notifly_ios_sdk.docc; sourceTree = "<group>"; };
 		673F0E8A29EBA7D200814217 /* notifly-ios-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "notifly-ios-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -170,6 +172,7 @@
 				F2E669732ADE5F7E00DF9CA0 /* UUID+.swift */,
 				F2E669742ADE5F7E00DF9CA0 /* TrackingEvent.swift */,
 				B0521E412C1B572100D4E357 /* Timezone.swift */,
+				2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */,
 			);
 			path = NotiflyUtil;
 			sourceTree = "<group>";
@@ -382,6 +385,7 @@
 				F2E6699D2ADE60AF00DF9CA0 /* NotiflyError.swift in Sources */,
 				F2E669A52ADE633400DF9CA0 /* Notifly+Helper.swift in Sources */,
 				673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */,
+				2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */,
 				F2E6699F2ADE60B500DF9CA0 /* Logger.swift in Sources */,
 				F2E669982ADE602900DF9CA0 /* TrackingManager.swift in Sources */,
 				F2E669992ADE602900DF9CA0 /* UserManager.swift in Sources */,

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/Campaign.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/Campaign.swift
@@ -36,7 +36,7 @@ struct Campaign {
         guard let id = from["id"] as? String,
               let channel = from["channel"] as? String,
               channel == InAppMessageConstant.inAppMessageChannel,
-              
+
               let triggeringConditions = try? TriggeringConditions(from: from["triggering_conditions"]),
 
               let rawStatusValue = from["status"] as? Int,
@@ -62,24 +62,24 @@ struct Campaign {
         self.id = id
 
         self.channel = channel
-        self.status = campaignStatus
+        status = campaignStatus
 
         self.triggeringConditions = triggeringConditions
-        self.triggeringEventFilters = try? TriggeringEventFilters(from: from["triggering_event_filters"])
+        triggeringEventFilters = try? TriggeringEventFilters(from: from["triggering_event_filters"])
 
         let campaignStarts: [Int] = (from["starts"] as? [Int]) ?? []
-        self.campaignStart = campaignStarts.count > 0 ? campaignStarts[0] : 0
-        self.campaignEnd = from["end"] as? Int
-        self.delay = (from["delay"] as? Int) ?? 0
-        self.reEligibleCondition = NotiflyReEligibleConditionEnum.ReEligibleCondition(from: from["re_eligible_condition"] as? [String: Any])
+        campaignStart = !campaignStarts.isEmpty ? campaignStarts[0] : 0
+        campaignEnd = from["end"] as? Int
+        delay = (from["delay"] as? Int) ?? 0
+        reEligibleCondition = NotiflyReEligibleConditionEnum.ReEligibleCondition(from: from["re_eligible_condition"] as? [String: Any])
 
         self.testing = testing
-        self.whitelist = testing ? from["whitelist"] as? [String] : []
+        whitelist = testing ? from["whitelist"] as? [String] : []
 
         self.segmentType = segmentType
-        self.segmentInfo = NotiflySegmentation.SegmentInfo(from: segmentInfoDict)
+        segmentInfo = NotiflySegmentation.SegmentInfo(from: segmentInfoDict)
 
-        self.message = Message(htmlURL: htmlURL, modalProperties: modalProperties)
+        message = Message(htmlURL: htmlURL, modalProperties: modalProperties)
 
         self.updatedAt = updatedAt
     }
@@ -155,7 +155,7 @@ struct TriggeringConditions {
 
     init(from: Any?) throws {
         guard let from = from as? [[[String: Any]]] else {
-        throw NotiflyError.invalidPayload
+            throw NotiflyError.invalidPayload
         }
 
         conditions = []
@@ -176,9 +176,9 @@ struct TriggeringConditions {
 
     func match(eventName: String) -> Bool {
         return conditions.contains {
-            $0.allSatisfy({
+            $0.allSatisfy {
                 NotiflyStringComparator.compare(reference: eventName, operator: $0.operator, rhs: $0.operand)
-            })
+            }
         }
     }
 }
@@ -194,10 +194,10 @@ struct TriggeringConditionUnit {
 
     init(from: [String: Any]) throws {
         guard let typeStr = from["type"] as? String,
-            let type = NotiflyTriggeringConditonType(rawValue: typeStr),
-            let operatorStr = from["operator"] as? String,
-            let `operator` = NotiflyStringOperator(rawValue: operatorStr),
-            let operand = from["operand"] as? String
+              let type = NotiflyTriggeringConditonType(rawValue: typeStr),
+              let operatorStr = from["operator"] as? String,
+              let `operator` = NotiflyStringOperator(rawValue: operatorStr),
+              let operand = from["operand"] as? String
         else {
             throw NotiflyError.invalidPayload
         }
@@ -268,7 +268,7 @@ enum TriggeringEventFilter {
     }
 
     static func matchFilterCondition(filters: TriggeringEventFilterArray, eventParams: [String: Any]?) -> Bool {
-        guard let params = eventParams, params.count > 0 else {
+        guard let params = eventParams, !params.isEmpty else {
             return false
         }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
@@ -45,7 +45,7 @@ class InAppMessageManager {
         if candidateCampaigns.isEmpty {
             return []
         }
-        let campaignsToTrigger = userStateManager.campaignData.inAppMessageCampaigns
+        let campaignsToTrigger = candidateCampaigns
             .filter {
                 isCampaignActive(campaign: $0)
             }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
@@ -61,7 +61,7 @@ class InAppMessageManager {
                 return SegmentationHelper.isEntityOfSegment(campaign: $0, eventParams: eventParams, userData: currentUserData, eventData: currentEventData)
             }
 
-        if campaignsToTrigger.count == 0 {
+        if campaignsToTrigger.isEmpty {
             return nil
         }
         return campaignsToTrigger

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
@@ -18,71 +18,25 @@ class InAppMessageManager {
         userStateManager = UserStateManager(owner: owner)
     }
 
-    func updateUserProperties(userID: String?, properties: [String: Any]) {
+    func mayTriggerInAppMessage(eventName: String, eventParams: [String: Any]?, segmentationEventParamKeys _: [String]?) {
         guard !Notifly.inAppMessageDisabled else {
             return
-        }
-        let updateTask = Notifly.keepGoingPub.sink(
-            receiveCompletion: { _ in },
-            receiveValue: { _ in
-                guard userID == self.userStateManager.owner else {
-                    Logger.error("Fail to update client-side user state (user properties): owner mismatch")
-                    return
-                }
-                self.userStateManager.updateUserData(userID: userID, properties: properties)
-            }
-        )
-        guard let main = try? Notifly.main, updateTask != nil else {
-            Logger.error("Fail to update client-side user state (user properties): Notifly is not initialized")
-            return
-        }
-        main.storeCancellable(cancellable: updateTask)
-    }
-
-    func updateEventData(userID: String?, eventName: String, eventParams: [String: Any]?, segmentationEventParamKeys: [String]?) {
-        guard !Notifly.inAppMessageDisabled else {
-            return
-        }
-
-        if let currentOwner = userStateManager.owner {
-            guard userID == currentOwner else {
-                Logger.error("Fail to update client-side user state (event): owner mismatch")
-                return
-            }
         }
 
         if var campaignsToTrigger = getCampaignsShouldBeTriggered(eventName: eventName, eventParams: eventParams) {
+            if campaignsToTrigger.isEmpty {
+                return
+            }
             campaignsToTrigger.sort(by: { $0.updatedAt > $1.updatedAt })
             for campaignToTrigger in campaignsToTrigger {
                 if let notiflyInAppMessageData = prepareInAppMessageData(campaign: campaignToTrigger) {
-                    showInAppMessage(userID: userID, notiflyInAppMessageData: notiflyInAppMessageData)
+                    showInAppMessage(
+                        userID: try? Notifly.main.userManager.getNotiflyUserID(),
+                        notiflyInAppMessageData: notiflyInAppMessageData
+                    )
                 }
             }
         }
-        userStateManager.incrementEic(eventName: eventName, eventParams: eventParams, segmentationEventParamKeys: segmentationEventParamKeys)
-    }
-
-    func updateHideCampaignUntilData(userID: String?, hideUntilData: [String: Int]) {
-        guard !Notifly.inAppMessageDisabled else {
-            return
-        }
-
-        guard userID == userStateManager.owner else {
-            Logger.error("Fail to update client-side user state (user campaign hidden until): owner mismatch")
-            return
-        }
-
-        let updateTask = Notifly.keepGoingPub.sink(
-            receiveCompletion: { _ in },
-            receiveValue: { _ in
-                self.userStateManager.updateUserCampaignHiddenUntilData(userID: userID, hideUntilData: hideUntilData)
-            }
-        )
-        guard let main = try? Notifly.main, updateTask != nil else {
-            Logger.error("Fail to update client-side user state (user campaign hidden until): Notifly is not initialized")
-            return
-        }
-        main.storeCancellable(cancellable: updateTask)
     }
 
     /* method for showing in-app message */
@@ -106,7 +60,7 @@ class InAppMessageManager {
                 let currentEventData: EventData = userStateManager.eventData
                 return SegmentationHelper.isEntityOfSegment(campaign: $0, eventParams: eventParams, userData: currentUserData, eventData: currentEventData)
             }
-        
+
         if campaignsToTrigger.count == 0 {
             return nil
         }
@@ -184,7 +138,10 @@ class InAppMessageManager {
         return nil
     }
 
-    private func showInAppMessage(userID: String?, notiflyInAppMessageData: InAppMessageData) {
+    private func showInAppMessage(
+        userID: String?,
+        notiflyInAppMessageData: InAppMessageData
+    ) {
         guard let userID = userID else {
             return
         }
@@ -194,10 +151,9 @@ class InAppMessageManager {
                 return
             }
 
-            
             let currentUserData = self.userStateManager.userData
             if let reEligibleCondition = notiflyInAppMessageData.notiflyReEligibleCondition {
-                guard !self.isHiddenCampaign(campaignID: notiflyInAppMessageData.notiflyCampaignId, userData: currentUserData ) else {
+                guard !self.isHiddenCampaign(campaignID: notiflyInAppMessageData.notiflyCampaignId, userData: currentUserData) else {
                     return
                 }
             }
@@ -205,7 +161,7 @@ class InAppMessageManager {
             guard !self.isBlacklistTemplate(templateName: notiflyInAppMessageData.modalProps.templateName, userData: currentUserData) else {
                 return
             }
-6
+            6
             guard WebViewModalViewController.openedInAppMessageCount == 0 else {
                 Logger.error("Already In App Message Opened. New In App Message Ignored.")
                 return

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/SegmentationHelper.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/SegmentationHelper.swift
@@ -50,7 +50,7 @@ enum SegmentationHelper {
         }
 
         let groupOp = segmentInfo.groupOperator
-        if groups.count == 0 || groupOp == nil {
+        if groups.isEmpty || groupOp == nil {
             return true
         }
         return false
@@ -58,7 +58,7 @@ enum SegmentationHelper {
 
     static func isEntityOfGroup(group: NotiflySegmentation.SegmentationGroup.Group, eventParams: [String: Any]?, userData: UserData, eventData: EventData) -> Bool {
         guard let conditions = group.conditions,
-              conditions.count > 0
+              !conditions.isEmpty
         else {
             return false
         }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserState+Constant.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserState+Constant.swift
@@ -1,4 +1,5 @@
 import Foundation
+
 //
 //  InAppMessage.swift
 //  notifly-ios-sdk
@@ -37,7 +38,7 @@ struct UserData {
         sdkVersion = NotiflyHelper.getSdkVersion()
         sdkType = NotiflyHelper.getSdkType()
         randomBucketNumber = NotiflyHelper.parseRandomBucketNumber(num: data["random_bucket_number"])
-        
+
         if let createdAtStr = data["created_at"] as? String {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
@@ -89,7 +90,7 @@ struct UserData {
             "user_properties": mergedUserProperties,
             "campaign_hidden_until": mergedCampaignHiddenUntil,
         ]
-        
+
         data["platform"] = p1.platform
         data["os_version"] = p1.osVersion
         data["sdk_type"] = p1.sdkType
@@ -119,7 +120,7 @@ struct UserData {
             "user_properties": userProperties,
             "campaign_hidden_until": campaignHiddenUntil,
         ]
-        
+
         data["platform"] = platform
         data["os_version"] = osVersion
         data["sdk_type"] = sdkType
@@ -130,7 +131,7 @@ struct UserData {
         if let sdkVersion = sdkVersion {
             data["sdk_version"] = sdkVersion
         }
-        
+
         if let createdAt = createdAt {
             data["created_at"] = createdAt
         }
@@ -237,7 +238,7 @@ enum EicHelper {
     static func selectEventParamsWithKeys(eventParams: [String: Any]?, segmentationEventParamKeys: [String]?) -> [String: String]? {
         if let segmentationEventParamKeys = segmentationEventParamKeys,
            let eventParams = eventParams,
-           segmentationEventParamKeys.count > 0,
+           !segmentationEventParamKeys.isEmpty,
            eventParams.count > 0
         {
             let keyField = segmentationEventParamKeys[0]

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
@@ -162,7 +162,7 @@ class UserStateManager {
 
     private func constructEventData(rawEventData: [[String: Any]], postProcessConfig: PostProcessConfigForSyncState) {
         let existing = postProcessConfig.merge ? eventData : EventData(from: [[:]])
-        let new = rawEventData.count > 0 && !postProcessConfig.clear ? EventData(from: rawEventData) : EventData(from: [[:]])
+        let new = !rawEventData.isEmpty && !postProcessConfig.clear ? EventData(from: rawEventData) : EventData(from: [[:]])
         eventData = EventData.merge(p1: existing, p2: new)
     }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
@@ -11,21 +11,76 @@ import Foundation
 
 @available(iOSApplicationExtension, unavailable)
 class UserStateManager {
-    var owner: String?
-    var campaignData: CampaignData = .init(from: [])
-    var userData: UserData = .init(data: [:])
-    var eventData: EventData = .init(eventCounts: [:])
-
-    private let userStateAccessQueue = DispatchQueue(label: "com.notifly.userStateAccessQueue")
-    private let userDataAccessQueue = DispatchQueue(label: "com.notifly.userDataAccessQueue")
-    private let eventDataAccessQueue = DispatchQueue(label: "com.notifly.eventDataAccessQueue")
-    private let campaignDataAccessQueue = DispatchQueue(label: "com.notifly.campaignDataAccessQueue")
-
-    private var _waitSyncStateFinishedPub: AnyPublisher<Void, Error>?
-    private(set) var waitSyncStateFinishedPub: AnyPublisher<Void, Error> {
+    private var _owner: String?
+    private let ownerAccessQueue = DispatchQueue(label: "com.yourapp.userStateManager.ownerQueue")
+    var owner: String? {
         get {
-            return userStateAccessQueue.sync {
-                if let pub = waitSyncStateCompletedPubs.last as? AnyPublisher<Void, Error> {
+            ownerAccessQueue.sync {
+                _owner
+            }
+        }
+        set {
+            ownerAccessQueue.sync {
+                _owner = newValue
+            }
+        }
+    }
+
+    private var _campaignData: CampaignData = .init(from: [])
+    private var _userData: UserData = .init(data: [:])
+    private var _eventData: EventData = .init(eventCounts: [:])
+    private var campaignDataAccessQueue = DispatchQueue(label: "com.yourapp.userStateManager.campaignDataAccessQueue")
+    private var userDataAccessQueue = DispatchQueue(label: "com.yourapp.userStateManager.userDataAccessQueue")
+    private var eventDataAccessQueue = DispatchQueue(label: "com.yourapp.userStateManager.eventDataAccessQueue")
+
+    var campaignData: CampaignData {
+        get {
+            campaignDataAccessQueue.sync {
+                _campaignData
+            }
+        }
+        set {
+            campaignDataAccessQueue.sync {
+                _campaignData = newValue
+            }
+        }
+    }
+
+    var userData: UserData {
+        get {
+            userDataAccessQueue.sync {
+                _userData
+            }
+        }
+        set {
+            userDataAccessQueue.sync {
+                _userData = newValue
+            }
+        }
+    }
+
+    var eventData: EventData {
+        get {
+            eventDataAccessQueue.sync {
+                _eventData
+            }
+        }
+        set {
+            eventDataAccessQueue.sync {
+                _eventData = newValue
+            }
+        }
+    }
+
+    var _waitPubs: [AnyPublisher<Void, Error>] = []
+    var _resolveLockPromises: [Future<Void, Error>.Promise] = []
+    var _handlingTimeoutTasks: [DispatchWorkItem] = []
+
+    private let syncStateQueue = DispatchQueue(label: "com.notifly.syncStateQueue")
+    var waitSyncStateFinishedPub: AnyPublisher<Void, Error> {
+        get {
+            return syncStateQueue.sync {
+                if let pub = _waitPubs.last as? AnyPublisher<Void, Error> {
                     return pub
                         .catch { _ in
                             Just(()).setFailureType(to: Error.self)
@@ -36,57 +91,56 @@ class UserStateManager {
                 }
             }
         }
-        set {
-            userStateAccessQueue.async {
-                self._waitSyncStateFinishedPub = newValue
+        set {}
+    }
+
+    var waitParentPub: AnyPublisher<Void, Error> {
+        get {
+            return syncStateQueue.sync {
+                let lockCount = _waitPubs.count
+                let parentLockIndex = lockCount > 1 ? lockCount - 2 : -1
+                let parentLock = lockCount > 1 ? _waitPubs[parentLockIndex] : nil
+                return Future<Void, Error> { promise in
+                    guard let parentLock = parentLock else {
+                        promise(.success(()))
+                        return
+                    }
+
+                    let task = parentLock
+                        .sink(receiveCompletion: { _ in
+                            promise(.success(()))
+                        }, receiveValue: { _ in })
+
+                    guard let main = try? Notifly.main, task != nil else {
+                        return
+                    }
+
+                    main.storeCancellable(cancellable: task)
+
+                }.eraseToAnyPublisher()
             }
         }
+        set {}
     }
-
-    var waitParentUnlockPub: AnyPublisher<Void, Never> {
-        let lockCount = waitSyncStateCompletedPubs.count
-        let parentLockIndex = lockCount > 1 ? lockCount - 2 : -1
-        let parentLock = lockCount > 1 ? waitSyncStateCompletedPubs[parentLockIndex] : nil
-        return Future<Void, Never> { promise in
-            if let parentLock = parentLock {
-                let task = parentLock
-                    .sink(receiveCompletion: { _ in
-                        promise(.success(()))
-                    }, receiveValue: { _ in })
-                guard let main = try? Notifly.main, task != nil else {
-                    return
-                }
-                main.storeCancellable(cancellable: task)
-
-            } else {
-                promise(.success(()))
-            }
-        }.eraseToAnyPublisher()
-    }
-
-    var waitSyncStateCompletedPubs: [AnyPublisher<Void, Error>] = []
-    var resolveLockPromises: [Future<Void, Error>.Promise] = []
-    var tasksHandlingTimeout: [DispatchWorkItem] = []
 
     init(owner: String?) {
-        self.owner = owner
+        _owner = owner
     }
 
-    /* manage sync state finished pub */
     func lock() -> Int {
-        return userStateAccessQueue.sync {
-            let lockId = resolveLockPromises.count
-            let waitSyncStateCompletedPub = Future { [weak self] promise in
-                self?.resolveLockPromises.append(promise)
+        return syncStateQueue.sync {
+            let lockId = _resolveLockPromises.count
+            let newWaitSyncStateCompletedPub = Future { [weak self] promise in
+                self?._resolveLockPromises.append(promise)
             }.eraseToAnyPublisher()
-            waitSyncStateCompletedPubs.append(waitSyncStateCompletedPub)
+            _waitPubs.append(newWaitSyncStateCompletedPub)
             return lockId
         }
     }
 
     private func unlock(lockId: Int, _ error: NotiflyError? = nil) {
-        userStateAccessQueue.async {
-            guard let promise = self.resolveLockPromises[safe: lockId] else {
+        syncStateQueue.async {
+            guard let promise = self._resolveLockPromises[safe: lockId] else {
                 return
             }
             if let err = error {
@@ -95,18 +149,18 @@ class UserStateManager {
                 promise(.success(()))
             }
 
-            if let task = self.tasksHandlingTimeout[safe: lockId] {
+            if let task = self._handlingTimeoutTasks[safe: lockId] {
                 task.cancel()
             }
         }
     }
 
     private func setTimeoutForLock(lockId: Int) {
-        userStateAccessQueue.async {
+        syncStateQueue.async {
             let newTask = DispatchWorkItem {
                 self.unlock(lockId: lockId)
             }
-            self.tasksHandlingTimeout.append(newTask)
+            self._handlingTimeoutTasks.append(newTask)
             DispatchQueue.main.asyncAfter(deadline: .now() + UserStateConstant.syncStateLockTimeout, execute: newTask)
         }
     }
@@ -131,9 +185,6 @@ class UserStateManager {
         }
 
         guard !Notifly.inAppMessageDisabled else {
-            for index in 0 ..< resolveLockPromises.count {
-                unlock(lockId: index)
-            }
             return
         }
 
@@ -147,7 +198,7 @@ class UserStateManager {
 
         let externalUserID = notifly.userManager.externalUserID
         let lockId = lock()
-        let task = waitParentUnlockPub
+        let task = waitParentPub
             .sink(receiveCompletion: { _ in
                       self.fetchUserCampaignContext(projectId: projectId, notiflyUserID: notiflyUserID, notiflyDeviceID: notiflyDeviceID, externalUserID: externalUserID, lockId: lockId, postProcessConfig: postProcessConfig)
                   },
@@ -181,13 +232,13 @@ class UserStateManager {
                     }
                 }
 
-                let userDataAsEventParams = self?.userData.destruct()
                 Logger.info("Sync State Completed.")
                 self?.owner = notiflyUserID
-                try? Notifly.main.trackingManager.trackSyncStateCompletedInternalEvent(userID: notiflyUserID, externalUserID: externalUserID, properties: userDataAsEventParams)
-
+                let fetchedUserData = self?.userData.destruct()
+                try? Notifly.main.trackingManager.trackSyncStateCompletedInternalEvent(userID: notiflyUserID, externalUserID: externalUserID, properties: fetchedUserData)
                 self?.unlock(lockId: lockId)
             })
+
         guard let main = try? Notifly.main, task != nil else {
             Logger.error("Fail to sync user state: Notifly is not initialized")
             unlock(lockId: lockId, NotiflyError.notInitialized)
@@ -198,82 +249,70 @@ class UserStateManager {
 
     /* post-process of sync state */
     private func constructUserData(rawUserData: [String: Any], postProcessConfig: PostProcessConfigForSyncState) {
-        userDataAccessQueue.async {
-            let newUserData = UserData(data: rawUserData)
-            if postProcessConfig.merge, let previousUserData = self.userData as? UserData {
-                self.userData = UserData.merge(p1: previousUserData, p2: newUserData)
-            } else {
-                self.userData = newUserData
-            }
-
-            if postProcessConfig.clear {
-                self.userData.clear()
-            }
+        var newUserData = UserData(data: rawUserData)
+        if postProcessConfig.merge, let previousUserData = userData as? UserData {
+            newUserData = UserData.merge(p1: previousUserData, p2: newUserData)
         }
+        if postProcessConfig.clear {
+            newUserData.clear()
+        }
+        userData = newUserData
     }
 
     private func constructEventData(rawEventData: [[String: Any]], postProcessConfig: PostProcessConfigForSyncState) {
-        eventDataAccessQueue.async {
-            let existing = postProcessConfig.merge ? self.eventData : EventData(from: [[:]])
-            let new = rawEventData.count > 0 && !postProcessConfig.clear ? EventData(from: rawEventData) : EventData(from: [[:]])
-            self.eventData = EventData.merge(p1: existing, p2: new)
-        }
+        let existing = postProcessConfig.merge ? eventData : EventData(from: [[:]])
+        let new = rawEventData.count > 0 && !postProcessConfig.clear ? EventData(from: rawEventData) : EventData(from: [[:]])
+        eventData = EventData.merge(p1: existing, p2: new)
     }
 
     private func constructCampaignData(rawCampaignData: [[String: Any]]) {
-        campaignDataAccessQueue.async {
-            self.campaignData = CampaignData(from: rawCampaignData)
-        }
+        campaignData = CampaignData(from: rawCampaignData)
     }
 
     /* update client state */
     func incrementEic(eventName: String, eventParams: [String: Any]?, segmentationEventParamKeys: [String]?) {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self = self else { return }
-            let dt = NotiflyHelper.getCurrentDate()
-            let eicID = EventIntermediateCount.generateId(eventName: eventName, eventParams: eventParams, segmentationEventParamKeys: segmentationEventParamKeys, dt: dt)
-            self.eventDataAccessQueue.async {
-                if var eic = self.eventData.eventCounts[eicID] {
-                    eic.addCount(count: 1)
-                    self.eventData.eventCounts[eicID] = eic
-                } else {
-                    self.eventData.eventCounts[eicID] = EventIntermediateCount(name: eventName, dt: dt, count: 1, eventParams: eventParams ?? [:])
-                }
-            }
+        let dt = NotiflyHelper.getCurrentDate()
+        let eicID = EventIntermediateCount.generateId(eventName: eventName, eventParams: eventParams, segmentationEventParamKeys: segmentationEventParamKeys, dt: dt)
+        if let eic = eventData.eventCounts[eicID] {
+            eventData.eventCounts[eicID] = EventIntermediateCount(name: eventName, dt: dt, count: eic.count + 1, eventParams: eventParams ?? [:])
+        } else {
+            eventData.eventCounts[eicID] = EventIntermediateCount(name: eventName, dt: dt, count: 1, eventParams: eventParams ?? [:])
         }
     }
 
     func getUserData(userID: String) -> UserData? {
-        return userDataAccessQueue.sync { [weak self] in
-            guard let self = self else {
-                return UserData(data: [:])
-            }
-            guard self.owner == userID else {
-                return UserData(data: [:])
-            }
-            return self.userData ?? UserData(data: [:])
+        guard owner == userID else {
+            return UserData(data: [:])
         }
+        return userData
     }
 
     func updateUserData(userID: String?, properties: [String: Any]) {
-        userDataAccessQueue.async { [weak self] in
-            guard let self = self else {
-                return
-            }
-            guard self.owner == userID else {
-                return
-            }
-            self.userData.userProperties.merge(properties) { _, new in new }
+        guard owner == userID else {
+            return
         }
+        userData.userProperties.merge(properties) { _, new in new }
+    }
+
+    func updateUserCampaignHiddenUntilData(
+        userID: String?,
+        hideUntilData: [String: Int]
+    ) {
+        guard userID == owner else {
+            Logger.error("Fail to update client-side user state (user campaign hidden until): owner mismatch")
+            return
+        }
+
+        userData.campaignHiddenUntil.merge(hideUntilData) { _, new in new }
+    }
+
+    func getInAppMessageCampaigns() -> [Campaign] {
+        return campaignData.inAppMessageCampaigns
     }
 
     func clear() {
-        userDataAccessQueue.async {
-            self.userData.clear()
-        }
-        eventDataAccessQueue.async {
-            self.eventData.clear()
-        }
+        userData.clear()
+        eventData.clear()
     }
 }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
@@ -106,15 +106,15 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
            let hideUntil = NotiflyHelper.calculateHideUntil(reEligibleCondition: reEligibleCondition)
         {
             hideUntilData = [campaignID: hideUntil]
-            if let main = try? Notifly.main, let manager = main.inAppMessageManager as? InAppMessageManager {
-                manager.updateHideCampaignUntilData(
+            if let main = try? Notifly.main, let userStateManager = main.inAppMessageManager.userStateManager as? UserStateManager {
+                userStateManager.updateUserCampaignHiddenUntilData(
                     userID: try? main.userManager.getNotiflyUserID(),
                     hideUntilData: [
                         campaignID: hideUntil,
                     ]
                 )
             } else {
-                Logger.error("InAppMessage manager is not exist.")
+                Logger.error("UserStateManager manager is not exist.")
             }
         }
 
@@ -198,7 +198,7 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                         hideUntil = -1
                     }
                     let newProperty = "hide_in_app_message_until_" + templateName
-                    try? Notifly.main.userManager.setUserProperties([newProperty: hideUntil])
+                    try? Notifly.main.userManager.setUserProperties(userProperties: [newProperty: hideUntil])
                 }
             case "survey_submit_button":
                 notifly.trackingManager.trackInternalEvent(eventName: TrackingConstant.Internal.inAppMessageSurveySubmitButtonClicked, eventParams: params)

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
@@ -70,7 +70,8 @@ class TrackingManager {
                     "notif_auth_status": authStatus,
                     "in_app_message_disabled": Notifly.inAppMessageDisabled,
                     "timezone": TimezoneUtil.getCurrentTimezoneId(),
-                ]
+                ],
+                lockAcquired: true
             )
         }
     }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/User/UserManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/User/UserManager.swift
@@ -63,10 +63,6 @@ class UserManager {
             Logger.error("Fail to Set User Id.")
             return
         }
-        guard externalUserID != newExternalUserID else {
-            Logger.info("External User Id is not changed because the new user id is same as the current user id.")
-            return
-        }
 
         if let data = [
             TrackingConstant.Internal.notiflyExternalUserID: newExternalUserID,
@@ -78,6 +74,13 @@ class UserManager {
                     Notifly.asyncWorker.unlock()
                     return
                 }
+
+                guard externalUserID != newExternalUserID else {
+                    Logger.info("External User Id is not changed because the new user id is same as the current user id.")
+                    Notifly.asyncWorker.unlock()
+                    return
+                }
+
                 let previousExternalUserID = externalUserID
                 changeExternalUserId(newValue: newExternalUserID)
                 let postProcessConfigForSyncState = constructPostProcessConfigForSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: newExternalUserID)

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/User/UserManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/User/UserManager.swift
@@ -4,29 +4,51 @@ import Foundation
 
 @available(iOSApplicationExtension, unavailable)
 class UserManager {
-    var externalUserID: String? {
-        didSet { // TODO:
-            if externalUserID == nil {
-                _notiflyUserIDCache = nil
+    private let userIdAccessQueue = DispatchQueue(label: "com.notifly.userManager.changeExternalUserIdQueue")
+
+    private var _notiflyUserIDCache: String?
+    var notiflyUserIDCache: String? {
+        get {
+            userIdAccessQueue.sync {
+                _notiflyUserIDCache
+            }
+        }
+        set {
+            userIdAccessQueue.sync {
+                _notiflyUserIDCache = newValue
             }
         }
     }
 
-    private var _notiflyUserIDCache: String?
+    private var _externalUserID: String?
+    var externalUserID: String? {
+        get {
+            userIdAccessQueue.sync {
+                _externalUserID
+            }
+        }
+        set {
+            userIdAccessQueue.sync {
+                _externalUserID = newValue
+            }
+        }
+    }
 
     init() {
         externalUserID = NotiflyCustomUserDefaults.externalUserIdInUserDefaults
     }
 
     private func changeExternalUserId(newValue: String?) {
-        _notiflyUserIDCache = nil
+        notiflyUserIDCache = nil
         externalUserID = newValue
-        NotiflyCustomUserDefaults.externalUserIdInUserDefaults = newValue
+        userIdAccessQueue.async {
+            NotiflyCustomUserDefaults.externalUserIdInUserDefaults = newValue
+        }
     }
 
     func setExternalUserId(_ newExternalUserID: String?) {
         if newExternalUserID == nil {
-            unregisteredUserId()
+            handleRemoveExternalUserId()
             return
         }
 
@@ -41,7 +63,6 @@ class UserManager {
             Logger.error("Fail to Set User Id.")
             return
         }
-
         guard externalUserID != newExternalUserID else {
             Logger.info("External User Id is not changed because the new user id is same as the current user id.")
             return
@@ -52,50 +73,68 @@ class UserManager {
             TrackingConstant.Internal.previousExternalUserID: externalUserID,
             TrackingConstant.Internal.previousNotiflyUserID: try? getNotiflyUserID(),
         ] as? [String: Any] {
-            let previousExternalUserID = externalUserID
-
-            changeExternalUserId(newValue: newExternalUserID)
-
-            let postProcessConfigForSyncState = constructPostProcessConfigForSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: newExternalUserID)
-            if shouldRequestSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: newExternalUserID) {
-                notifly.inAppMessageManager.userStateManager.syncState(postProcessConfig: postProcessConfigForSyncState)
+            Notifly.asyncWorker.addTask { [weak self] in
+                guard let self = self else {
+                    Notifly.asyncWorker.unlock()
+                    return
+                }
+                let previousExternalUserID = externalUserID
+                changeExternalUserId(newValue: newExternalUserID)
+                let postProcessConfigForSyncState = constructPostProcessConfigForSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: newExternalUserID)
+                if shouldRequestSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: newExternalUserID) {
+                    notifly.inAppMessageManager.userStateManager.syncState(postProcessConfig: postProcessConfigForSyncState) {
+                        self.setUserProperties(userProperties: data, lockAcquired: true)
+                    }
+                } else {
+                    self.setUserProperties(userProperties: data, lockAcquired: true)
+                }
             }
-            setUserProperties(data)
+
         } else {
             Logger.error("Fail to Set User Id.")
         }
     }
 
-    private func unregisteredUserId() {
+    private func handleRemoveExternalUserId() {
         guard let notifly = try? Notifly.main else {
             Logger.error("Fail to Remove User Id: Notifly is not initialized yet.")
             return
         }
-        let previousExternalUserID = externalUserID
 
-        changeExternalUserId(newValue: nil)
-        let postProcessConfigForSyncState = constructPostProcessConfigForSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: nil)
-        
-        if shouldRequestSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: nil) {
-            notifly.inAppMessageManager.userStateManager.syncState(postProcessConfig: postProcessConfigForSyncState)
-        } else {
-            notifly.inAppMessageManager.userStateManager.clear()
+        Notifly.asyncWorker.addTask { [weak self] in
+            guard let self = self else {
+                Notifly.asyncWorker.unlock()
+                return
+            }
+            let previousExternalUserID = externalUserID
+            self.changeExternalUserId(newValue: nil)
+
+            let postProcessConfigForSyncState = constructPostProcessConfigForSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: nil)
+            if shouldRequestSyncState(previousExternalUserID: previousExternalUserID, newExternalUserID: nil) {
+                notifly.inAppMessageManager.userStateManager.syncState(postProcessConfig: postProcessConfigForSyncState) {
+                    notifly.trackingManager.trackInternalEvent(eventName: TrackingConstant.Internal.removeUserPropertiesEventName, eventParams: nil, lockAcquired: true)
+                }
+            } else {
+                notifly.inAppMessageManager.userStateManager.clear()
+                notifly.trackingManager.trackInternalEvent(eventName: TrackingConstant.Internal.removeUserPropertiesEventName, eventParams: nil, lockAcquired: true)
+            }
         }
-
-        notifly.trackingManager.trackInternalEvent(eventName: TrackingConstant.Internal.removeUserPropertiesEventName, eventParams: nil)
     }
 
-    func setUserProperties(_ userProperties: [String: Any]) {
+    func setUserProperties(userProperties: [String: Any], lockAcquired: Bool = false) {
         guard let notifly = try? Notifly.main else {
             Logger.error("Fail to Set User Properties: Notifly is not initialized yet.")
             return
         }
-        notifly.inAppMessageManager.updateUserProperties(
-            userID: try? getNotiflyUserID(),
-            properties: userProperties
-        )
-        
-        notifly.trackingManager.trackInternalEvent(eventName: TrackingConstant.Internal.setUserPropertiesEventName, eventParams: userProperties)
+
+        if !Notifly.inAppMessageDisabled {
+            notifly.inAppMessageManager.userStateManager.updateUserData(
+                userID: try? getNotiflyUserID(),
+                properties: userProperties
+            )
+        }
+
+        notifly.trackingManager.trackInternalEvent(eventName: TrackingConstant.Internal.setUserPropertiesEventName, eventParams: userProperties, lockAcquired: lockAcquired)
     }
 
     func getNotiflyUserID() throws -> String {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -63,15 +63,17 @@ import UIKit
             }
         }
 
-        Messaging.messaging().token { token, error in
-            if let token = token,
-               error == nil
-            {
-                try? main.notificationsManager.deviceTokenPromise?(.success(token))
-                main.notificationsManager.setDeviceTokenPub(token: token)
+        Notifly.asyncWorker.addTask {
+            Messaging.messaging().token { token, error in
+                if let token = token,
+                   error == nil
+                {
+                    try? main.notificationsManager.deviceTokenPromise?(.success(token))
+                    main.notificationsManager.setDeviceTokenPub(token: token)
+                }
+                try? main.trackingManager.trackSessionStartInternalEvent()
+                Logger.info("📡 Notifly SDK is successfully initialized.")
             }
-            try? main.trackingManager.trackSessionStartInternalEvent()
-            Logger.info("📡 Notifly SDK is successfully initialized.")
         }
     }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -173,7 +173,7 @@ import UIKit
             return
         }
 
-        if userProperties.count == 0 {
+        if userProperties.isEmpty {
             Logger.info("Empty dictionary provided for setting user properties. Ignoring this call.")
             return
         }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/AsyncWorker.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/AsyncWorker.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+class NotiflyAsyncWorker {
+    private let semaphore: DispatchSemaphore
+    private var pendingTasks: [() -> Void] = []
+    private let queue = DispatchQueue(label: "com.notifly.asyncWorkerQueue")
+
+    init(semaphoreValue: Int = 1) {
+        semaphore = DispatchSemaphore(value: semaphoreValue)
+    }
+
+    private func performAsyncTask(task: @escaping () -> Void) {
+        queue.async {
+            task()
+        }
+    }
+
+    private func executePendingTask() {
+        queue.async {
+            if let nextTask = self.pendingTasks.first {
+                if self.semaphore.wait(timeout: .now()) == .success {
+                    self.pendingTasks.removeFirst()
+                    self.performAsyncTask(task: nextTask)
+                }
+            }
+        }
+    }
+
+    func addTask(lockAcquired: Bool = false, task: @escaping () -> Void) {
+        if lockAcquired {
+            queue.async {
+                self.performAsyncTask(task: task)
+            }
+            return
+        }
+
+        if semaphore.wait(timeout: .now()) == .success {
+            performAsyncTask(task: task)
+        } else {
+            queue.async {
+                self.pendingTasks.append(task)
+            }
+        }
+    }
+
+    func unlock() {
+        semaphore.signal()
+        executePendingTask()
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/AsyncWorker.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/AsyncWorker.swift
@@ -4,6 +4,7 @@ class NotiflyAsyncWorker {
     private let semaphore: DispatchSemaphore
     private var pendingTasks: [() -> Void] = []
     private let queue = DispatchQueue(label: "com.notifly.asyncWorkerQueue")
+    private var unlockSchedules: [DispatchWorkItem] = []
 
     init(semaphoreValue: Int = 1) {
         semaphore = DispatchSemaphore(value: semaphoreValue)
@@ -15,10 +16,16 @@ class NotiflyAsyncWorker {
         }
     }
 
-    private func executePendingTask() {
-        queue.async {
-            if let nextTask = self.pendingTasks.first {
+    private func executeNextTaskIfNeeded() {
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            if !self.pendingTasks.isEmpty,
+               let nextTask = self.pendingTasks.first
+            {
                 if self.semaphore.wait(timeout: .now()) == .success {
+                    self.registerUnlockSchedule()
                     self.pendingTasks.removeFirst()
                     self.performAsyncTask(task: nextTask)
                 }
@@ -28,23 +35,54 @@ class NotiflyAsyncWorker {
 
     func addTask(lockAcquired: Bool = false, task: @escaping () -> Void) {
         if lockAcquired {
-            queue.async {
+            queue.async { [weak self] in
+                guard let self = self else {
+                    return
+                }
                 self.performAsyncTask(task: task)
             }
             return
         }
 
         if semaphore.wait(timeout: .now()) == .success {
+            registerUnlockSchedule()
             performAsyncTask(task: task)
         } else {
-            queue.async {
+            queue.async { [weak self] in
+                guard let self = self else {
+                    return
+                }
                 self.pendingTasks.append(task)
             }
         }
     }
 
     func unlock() {
-        semaphore.signal()
-        executePendingTask()
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            if !self.unlockSchedules.isEmpty,
+               let unlockSchedule = self.unlockSchedules.first
+            {
+                unlockSchedule.cancel()
+                self.unlockSchedules.removeFirst()
+                semaphore.signal()
+                executeNextTaskIfNeeded()
+            }
+        }
+    }
+
+    private func registerUnlockSchedule() {
+        let timeoutTask = DispatchWorkItem {
+            self.unlock()
+        }
+        queue.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.unlockSchedules.append(timeoutTask)
+            self.queue.asyncAfter(deadline: .now() + 10, execute: timeoutTask)
+        }
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflyConstant {
-    static let sdkVersion: String = "1.10.1"
+    static let sdkVersion: String = "1.11.0"
     static let iosPlatform: String = "ios"
     static let projectIdRegex: String = "^[0-9a-fA-F]{32}$"
     enum EndPoint {

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '1.10.1'
+  s.version          = '1.11.0'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 1.10.1
+  NOTIFLY iOS SDK : 1.11.0
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary
1. when accessing shared resources, add defending logic to avoid multi-threading crash issue.
2. defend cocurrent sync state request logic error using semaphore (Notifly Async Worker)

## Describe your changes

## Issue ticket number and link
