### PR TITLE
feat: fix cocoapods minimum deployment target mismatch issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       version:
         description: "Version to be released"
         required: true
+      skip_cocoapods:
+        description: "Skip CocoaPods release step"
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -34,6 +38,7 @@ jobs:
 
       # https://fuller.li/posts/automated-cocoapods-releases-with-ci/
       - name: Release to CocoaPods
+        if: ${{ github.event.inputs.skip_cocoapods == false }}
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.16.2] - 2025-03-25
+
+- Fix Cocoapods minimum deployment target mismatch issue.
+
 ## [1.16.1] - 2025-03-14
 
 - Pass `link` event param to main_button_click event callback.

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "1.16.1"
+    static let sdkVersion: String = "1.16.2"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '1.16.1'
+  s.version          = '1.16.2'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 1.16.1
+  NOTIFLY iOS SDK : 1.16.2
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '13.0'
   s.swift_versions = '5.0'
+  s.pod_target_xcconfig = { 'IPHONEOS_DEPLOYMENT_TARGET' => '13.0' }
 
   s.subspec 'Full' do |full|
     full.source_files = 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/**/*'
@@ -22,7 +23,8 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Extension' do |e|
-    e.source_files = ['Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyExtension/**/*.swift', 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/**/*.swift', 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/PrivacyInfo.xcprivacy']
+    e.source_files = ['Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyExtension/**/*.swift', 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/**/*.swift']
+    e.resources = ["Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/PrivacyInfo.xcprivacy"]
   end
 
 end

--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
     s.name             = 'notifly_sdk_push_extension'
-    s.version          = '1.14.2'
+    s.version          = '1.14.3'
     s.summary          = 'Notifly iOS SDK.'
   
     s.description      = <<-DESC
-    NOTIFLY iOS Push Extension SDK : 1.14.2
+    NOTIFLY iOS Push Extension SDK : 1.14.3
     DESC
   
     s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'
@@ -13,7 +13,9 @@ Pod::Spec.new do |s|
     s.source           = { :git => 'https://github.com/team-michael/notifly-ios-sdk.git', :tag => s.version.to_s  }
   
     s.ios.deployment_target = '13.0'
+    s.pod_target_xcconfig = { 'IPHONEOS_DEPLOYMENT_TARGET' => '13.0' }
     s.swift_versions = '5.0'
-    s.source_files = source_files = ['Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyExtension/**/*.swift', 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/**/*.swift', 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/PrivacyInfo.xcprivacy']
+    s.source_files = ['Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyExtension/**/*.swift', 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/**/*.swift']
+    s.resources = ["Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/PrivacyInfo.xcprivacy"]
   end
   

--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -18,4 +18,3 @@ Pod::Spec.new do |s|
     s.source_files = ['Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyExtension/**/*.swift', 'Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/**/*.swift']
     s.resources = ["Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/PrivacyInfo.xcprivacy"]
   end
-  


### PR DESCRIPTION
<!--
    노티플라이 코드리뷰 규칙
    - https://www.notion.so/greyboxhq/Code-Review-b4158492767c4e5a86d5185390e1bcea
    - https://www.notion.so/greyboxhq/Code-Review-a4ca07eb7160408398bab5aeef3ea14a
    - 리뷰어는 기본 2+명을 지정해주세요.
-->
## Summary
- notifly_sdk_push_extension 가 cocoapods에 1.14.2로 릴리즈 된 이후 minimum deployment target 이 15.1로 변경된 이슈 수정

## Ref
<!--
    - 연관있는 Jira Ticket 및 기타 스펙 관련 자료들 PRD, Figma, Tech spec, etc.
-->
- JIRA ticket : https://greyboxhq.atlassian.net/browse/NOTIFLY-3317