### PR TITLE
feat: fix Info.plist to solve firebase FirebaseAppDelegateProxyEnabled error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           xcodebuild clean build \
             -project ./Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj \
             -scheme notifly-ios-sdk \
-            -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=17.5' \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.0' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO
 

--- a/NotiflyIOSSample/NotiflyIOSSample/Info.plist
+++ b/NotiflyIOSSample/NotiflyIOSSample/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
<!--
    노티플라이 코드리뷰 규칙
    - https://www.notion.so/greyboxhq/Code-Review-b4158492767c4e5a86d5185390e1bcea
    - https://www.notion.so/greyboxhq/Code-Review-a4ca07eb7160408398bab5aeef3ea14a
    - 리뷰어는 기본 2+명을 지정해주세요.
-->
## Summary
<!--
    - PR 개요, 변경사항, 중점적으로 보아야 하는 부분 작성.
    - 셀프 머지를 해야되는 경우 사유를 작성하고 라벨을 설정해주세요.
-->
- Info.plist에 FirebaseAppDelegateProxyEnabled 를 추가하여 IOSSample앱(spm 테스트)에서 토큰이 등록되지 않는 버그를 해결합니다.

11.11.0 - [FirebaseMessaging][I-FCM001000] FIRMessaging Remote Notifications proxy enabled, will swizzle remote notification receiver handlers. If you’d prefer to manually integrate Firebase Messaging, add “FirebaseAppDelegateProxyEnabled” to your Info.plist, and set it to NO. Follow the instructions at:
https://firebase.google.com/docs/cloud-messaging/ios/client#method_swizzling_in_firebase_messaging
to ensure proper integration.

과 같은 에러가 발생하고 있었고, 저러면 didRegisterForRemoteNotificationsWithDeviceToken가 불리지 않아 토큰 등록에 실패하는 이슈로 샘플앱에서 푸시를 못 받고 있는 것 같습니다.
1.16, 1.17 버전 무관하게 발생하여 해당 부분을 수정합니다.

## Ref
<!--
    - 연관있는 Jira Ticket 및 기타 스펙 관련 자료들 PRD, Figma, Tech spec, etc.
-->
- JIRA ticket : https://greyboxhq.atlassian.net/browse/NOTIFLY-
## Appendix (optional)
<!--
    - 변경사항에 대한 스크린샷, 또는 관련 링크, 자료들.
-->
- 
