### PR TITLE
feat: handle external user id mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),  
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.3] - 2025-07-24
+
+### Added
+
+- Handle external user ID mismatch between database and SDK
+
 ## [1.17.2] - 2025-07-16
 
 ### Added
+
 - Add `templateName` event params to in_app_message_show
 
 ## [1.17.1] - 2025-06-13
 
 ### Fixed
+
 - Resolve APNs/FCM token timing issues with retry mechanism
 - Remove duplicate FCM token request from PublicAPI initialize method
 - Remove unnecessary try? keywords to eliminate compiler warnings
@@ -19,160 +27,192 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.17.0] - 2025-04-16
 
 ### Added
+
 - Support in-app message template with transparent background.
 
 ## [1.16.3] - 2025-04-01
 
 ### Fixed
+
 - Change deployment targets to 13.0.
 
 ## [1.16.2] - 2025-03-25
 
 ### Fixed
+
 - Fix Cocoapods minimum deployment target mismatch issue.
 
 ## [1.16.1] - 2025-03-14
 
 ### Changed
+
 - Pass `link` event param to main_button_click event callback.
 
 ## [1.16.0] - 2025-03-10
 
 ### Added
+
 - Added `addInAppMessageEventListener` to provide a interface to listen events from InAppMessage WebView.
 
 ## [1.15.0] - 2025-01-16
 
 ### Added
+
 - Add `getNotiflyUserId()` method to get Notifly user ID.
 
 ## [1.14.2] - 2024-11-21
 
 ### Changed
+
 - Update Firebase dependency version to 20.0.0.
 
 ## [1.14.1] - 2024-08-27
 
 ### Changed
+
 - Change event tracking partition key to `notifly_device_id`.
 
 ## [1.14.0] - 2024-08-27
 
 ### Added
+
 - Support for user metadata conditions (`user_id`, `random_bucket_number`) in in-app message campaigns.
 
 ## [1.13.1] - 2024-07-10
 
 ### Changed
+
 - Open `NotiflyAnyCodable` to public.
 
 ## [1.13.0] - 2024-07-10
 
 ### Changed
+
 - Change tracking event endpoint.
 
 ### Fixed
+
 - Bug fixes for `AnyCodable` (Boolean).
 
 ## [1.12.1] - 2024-07-01
 
 ### Changed
+
 - Change variable names for improved clarity.
 
 ## [1.12.0] - 2024-06-30
 
 ### Added
+
 - Separate `PushExtension` SDK from `Notifly SDK` (`notifly_sdk_push_extension`).
 
 ## [1.11.0] - 2024-06-24
 
 ### Changed
+
 - Update user state management logic using access queues.
 - Replace user state locks with `NotiflyAsyncWorker` (Semaphore).
 
 ## [1.10.1] - 2024-06-20
 
 ### Fixed
+
 - Fix main-thread checker warning.
 
 ## [1.10.0] - 2024-06-14
 
 ### Added
+
 - Add `setTimezone`, `setPhoneNumber`, `setEmail` for convenience.
 - Automatic tracking of the user's timezone for device properties.
 
 ## [1.9.0] - 2024-05-27
 
 ### Fixed
+
 - Defend against crashes caused by concurrency issues during cancellable event storage.
 
 ## [1.8.0] - 2024-05-17
 
 ### Added
+
 - Support advanced triggering conditions.
 - Add custom headers to identify platform, SDK version, and SDK wrapper version.
 
 ## [1.7.1] - 2024-05-08
 
 ### Fixed
+
 - Address crashes caused by concurrency issues while updating user event data.
 
 ## [1.7.0] - 2024-04-25
 
 ### Added
+
 - Add privacy manifest.
 
 ## [1.6.1] - 2024-04-01
 
 ### Added
+
 - Add `.list` option to default foreground push notification presentation options.
 
 ## [1.6.0] - 2024-03-13
 
 ### Fixed
+
 - Perform additional validation before presenting in-app popups.
 
 ## [1.5.0] - 2024-03-06
 
 ### Added
+
 - Track GCM message ID in Push Extension.
 - Add urgent tracking events.
 
 ## [1.4.1] - 2024-03-06
 
 ### Removed
+
 - Remove version dependency on `FirebaseMessaging`.
 
 ## [1.4.0] - 2024-01-18
 
 ### Added
+
 - Support user segmentation with random bucket numbers and external user IDs.
 - Support `IS_NULL` and `IS_NOT_NULL` operators in user segmentation.
 - Add `TriggeringEventFilters` with event parameters.
 
 ### Fixed
+
 - Make sync state tasks asynchronous.
 
 ## [1.3.0] - 2023-10-20
 
 ### Added
+
 - Implement Push Extension as a SubSpec module.
 - Add re-eligibility condition for campaigns.
 
 ### Fixed
+
 - Various bug fixes.
 
 ## [1.2.1] - 2023-10-11
 
 ### Added
+
 - Extend push notification capabilities.
 
 ## [1.2.0] - 2023-10-06
 
 ### Added
+
 - Support re-eligibility conditions for in-app campaigns.
 
 ## [1.0.0] - 2023-05-26
 
 ### Added
+
 - Initial release.

--- a/NotiflyTestApp/NotiflyTestApp.xcodeproj/project.pbxproj
+++ b/NotiflyTestApp/NotiflyTestApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		675EB43E29ED18B1001347FB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 675EB43D29ED18B1001347FB /* Assets.xcassets */; };
 		675EB44129ED18B1001347FB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 675EB43F29ED18B1001347FB /* LaunchScreen.storyboard */; };
 		67A0706529F2270C0028DE1A /* UserSettingsTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A0706429F2270C0028DE1A /* UserSettingsTestViewController.swift */; };
+		7F0908BD2E2F688C00844D52 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7F0908BC2E2F688C00844D52 /* GoogleService-Info.plist */; };
 		F21322EF2A0243D900C3EE43 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F21322EC2A0243D900C3EE43 /* GoogleService-Info.plist */; };
 		F22B77BC2AA98B6800F7C432 /* notifly_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F22B77B72AA989A400F7C432 /* notifly_ios_sdk.framework */; };
 		F2DF20CC2AB17AB700CB9703 /* notifly_ios_sdk.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F260C4202AB17A9300394B5B /* notifly_ios_sdk.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -123,6 +124,7 @@
 		675EB44029ED18B1001347FB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		675EB44229ED18B1001347FB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		67A0706429F2270C0028DE1A /* UserSettingsTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsTestViewController.swift; sourceTree = "<group>"; };
+		7F0908BC2E2F688C00844D52 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F21322EC2A0243D900C3EE43 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F21322F02A02445D00C3EE43 /* NotiflyTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotiflyTestApp.entitlements; sourceTree = "<group>"; };
 		F22B77B12AA989A400F7C432 /* notifly-ios-sdk.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "notifly-ios-sdk.xcodeproj"; path = "../Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj"; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 				675EB43D29ED18B1001347FB /* Assets.xcassets */,
 				675EB43F29ED18B1001347FB /* LaunchScreen.storyboard */,
 				675EB44229ED18B1001347FB /* Info.plist */,
+				7F0908BC2E2F688C00844D52 /* GoogleService-Info.plist */,
 			);
 			path = NotiflyTestApp;
 			sourceTree = "<group>";
@@ -386,6 +389,7 @@
 			files = (
 				675EB44129ED18B1001347FB /* LaunchScreen.storyboard in Resources */,
 				F21322EF2A0243D900C3EE43 /* GoogleService-Info.plist in Resources */,
+				7F0908BD2E2F688C00844D52 /* GoogleService-Info.plist in Resources */,
 				675EB43E29ED18B1001347FB /* Assets.xcassets in Resources */,
 				675EB43C29ED18B0001347FB /* Main.storyboard in Resources */,
 			);

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
@@ -30,11 +30,14 @@ class UserStateManager {
     private var _userData: UserData = .init(data: [:])
     private var _eventData: EventData = .init(eventCounts: [:])
     private var campaignDataAccessQueue = DispatchQueue(
-        label: "com.yourapp.userStateManager.campaignDataAccessQueue")
+        label: "com.yourapp.userStateManager.campaignDataAccessQueue"
+    )
     private var userDataAccessQueue = DispatchQueue(
-        label: "com.yourapp.userStateManager.userDataAccessQueue")
+        label: "com.yourapp.userStateManager.userDataAccessQueue"
+    )
     private var eventDataAccessQueue = DispatchQueue(
-        label: "com.yourapp.userStateManager.eventDataAccessQueue")
+        label: "com.yourapp.userStateManager.eventDataAccessQueue"
+    )
 
     var campaignData: CampaignData {
         get {
@@ -82,6 +85,7 @@ class UserStateManager {
     /* sync state from notifly server */
     func syncState(
         postProcessConfig: PostProcessConfigForSyncState,
+        handleExternalUserIdMismatch: Bool = false,
         completion: @escaping () -> Void
     ) {
         guard let notifly = (try? Notifly.main) else {
@@ -103,9 +107,10 @@ class UserStateManager {
             return
         }
 
-        let externalUserID = notifly.userManager.externalUserID
         let syncStateTask = NotiflyAPI().requestSyncState(
-            projectId: projectId, notiflyUserID: notiflyUserID, notiflyDeviceID: notiflyDeviceID
+            projectId: projectId,
+            notiflyUserID: notiflyUserID,
+            notiflyDeviceID: notiflyDeviceID
         )
         .sink(
             receiveCompletion: { syncStateCompletion in
@@ -114,28 +119,71 @@ class UserStateManager {
                 }
             },
             receiveValue: { [weak self] jsonString in
+                guard let notifly = try? Notifly.main else {
+                    completion()
+                    return
+                }
+
+                var deviceExternalUserID: String? = nil
+
                 if let userState = NotiflyAnyCodable.parseJsonString(jsonString) {
                     if let rawUserData = userState["userData"] as? [String: Any] {
+                        deviceExternalUserID = rawUserData["device_external_user_id"] as? String
+                        if let id = deviceExternalUserID, id.isEmpty {
+                            deviceExternalUserID = nil
+                        }
+
                         self?.constructUserData(
-                            rawUserData: rawUserData, postProcessConfig: postProcessConfig)
+                            rawUserData: rawUserData,
+                            postProcessConfig: postProcessConfig
+                        )
                     }
 
                     if let rawEventData = userState["eventIntermediateCountsData"]
                         as? [[String: Any]]
                     {
                         self?.constructEventData(
-                            rawEventData: rawEventData, postProcessConfig: postProcessConfig)
+                            rawEventData: rawEventData,
+                            postProcessConfig: postProcessConfig
+                        )
                     }
 
                     if let rawCampaignData = userState["campaignData"] as? [[String: Any]] {
                         self?.constructCampaignData(rawCampaignData: rawCampaignData)
                     }
                 }
+
+                // DB의 디바이스-유저 매핑 정보와 SDK에 저장된 유저 정보가 다른 경우
+                // DB를 Source of Truth로 하여 SDK의 external_user_id를 DB 값으로 변경
+                if handleExternalUserIdMismatch {
+                    let sdkExternalUserID = notifly.userManager.externalUserID
+
+                    // 두 값이 모두 존재하고 서로 다른 경우에만 처리
+                    // DB가 null인 경우는 다양한 원인(쿼리 에러, 디바이스 미저장 등)으로 인해 실제 값이 null이 아닐 가능성이 있어 핸들링하지 않음
+                    // SDK가 null인 경우는 앱 재설치 등으로 허용되는 상황이므로 핸들링하지 않음
+                    if sdkExternalUserID != nil, deviceExternalUserID != nil,
+                        sdkExternalUserID != deviceExternalUserID
+                    {
+                        // SDK의 external_user_id를 DB 값으로 변경
+                        notifly.userManager.changeExternalUserId(newValue: deviceExternalUserID)
+
+                        notifly.inAppMessageManager.userStateManager.syncState(
+                            postProcessConfig: PostProcessConfigForSyncState(
+                                merge: false,
+                                clear: false
+                            )
+                        ) {
+                            completion()
+                        }
+                        return
+                    }
+                }
+
                 Logger.info("Sync State Completed.")
                 self?.owner = notiflyUserID
                 completion()
-
-            })
+            }
+        )
 
         guard let main = try? Notifly.main, syncStateTask != nil else {
             Logger.error("Fail to sync user state: Notifly is not initialized")
@@ -147,7 +195,8 @@ class UserStateManager {
 
     /* post-process of sync state */
     private func constructUserData(
-        rawUserData: [String: Any], postProcessConfig: PostProcessConfigForSyncState
+        rawUserData: [String: Any],
+        postProcessConfig: PostProcessConfigForSyncState
     ) {
         var newUserData = UserData(data: rawUserData)
         if postProcessConfig.merge, let previousUserData = userData as? UserData {
@@ -160,7 +209,8 @@ class UserStateManager {
     }
 
     private func constructEventData(
-        rawEventData: [[String: Any]], postProcessConfig: PostProcessConfigForSyncState
+        rawEventData: [[String: Any]],
+        postProcessConfig: PostProcessConfigForSyncState
     ) {
         let existing = postProcessConfig.merge ? eventData : EventData(from: [[:]])
         let new =
@@ -175,15 +225,24 @@ class UserStateManager {
 
     /* update client state */
     func incrementEic(
-        eventName: String, eventParams: [String: Any]?, segmentationEventParamKeys: [String]?
+        eventName: String,
+        eventParams: [String: Any]?,
+        segmentationEventParamKeys: [String]?
     ) {
         let dt = NotiflyHelper.getCurrentDate()
         let eicID = EventIntermediateCount.generateId(
-            eventName: eventName, eventParams: eventParams,
-            segmentationEventParamKeys: segmentationEventParamKeys, dt: dt)
+            eventName: eventName,
+            eventParams: eventParams,
+            segmentationEventParamKeys: segmentationEventParamKeys,
+            dt: dt
+        )
         if eventData.eventCounts[eicID] == nil {
             eventData.eventCounts[eicID] = EventIntermediateCount(
-                name: eventName, dt: dt, count: 0, eventParams: eventParams ?? [:])
+                name: eventName,
+                dt: dt,
+                count: 0,
+                eventParams: eventParams ?? [:]
+            )
         }
         eventData.eventCounts[eicID]?.addCount(count: 1)
     }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
@@ -119,24 +119,19 @@ class UserStateManager {
                 }
             },
             receiveValue: { [weak self] jsonString in
-                guard let notifly = try? Notifly.main else {
-                    completion()
-                    return
-                }
-
                 var deviceExternalUserID: String? = nil
 
                 if let userState = NotiflyAnyCodable.parseJsonString(jsonString) {
                     if let rawUserData = userState["userData"] as? [String: Any] {
-                        deviceExternalUserID = rawUserData["device_external_user_id"] as? String
-                        if let id = deviceExternalUserID, id.isEmpty {
-                            deviceExternalUserID = nil
-                        }
-
                         self?.constructUserData(
                             rawUserData: rawUserData,
                             postProcessConfig: postProcessConfig
                         )
+
+                        deviceExternalUserID = rawUserData["device_external_user_id"] as? String
+                        if let id = deviceExternalUserID, id.isEmpty {
+                            deviceExternalUserID = nil
+                        }
                     }
 
                     if let rawEventData = userState["eventIntermediateCountsData"]
@@ -156,6 +151,11 @@ class UserStateManager {
                 // DB의 디바이스-유저 매핑 정보와 SDK에 저장된 유저 정보가 다른 경우
                 // DB를 Source of Truth로 하여 SDK의 external_user_id를 DB 값으로 변경
                 if handleExternalUserIdMismatch {
+                    guard let notifly = try? Notifly.main else {
+                        completion()
+                        return
+                    }
+
                     let sdkExternalUserID = notifly.userManager.externalUserID
 
                     // 두 값이 모두 존재하고 서로 다른 경우에만 처리

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/User/UserManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/User/UserManager.swift
@@ -5,7 +5,8 @@ import Foundation
 @available(iOSApplicationExtension, unavailable)
 class UserManager {
     private let userIdAccessQueue = DispatchQueue(
-        label: "com.notifly.userManager.changeExternalUserIdQueue")
+        label: "com.notifly.userManager.changeExternalUserIdQueue"
+    )
 
     private var _notiflyUserIDCache: String?
     var notiflyUserIDCache: String? {
@@ -39,7 +40,7 @@ class UserManager {
         externalUserID = NotiflyCustomUserDefaults.externalUserIdInUserDefaults
     }
 
-    private func changeExternalUserId(newValue: String?) {
+    func changeExternalUserId(newValue: String?) {
         notiflyUserIDCache = nil
         externalUserID = newValue
         userIdAccessQueue.async {
@@ -68,7 +69,7 @@ class UserManager {
         if let data = [
             TrackingConstant.Internal.notiflyExternalUserID: newExternalUserID,
             TrackingConstant.Internal.previousExternalUserID: externalUserID,
-            TrackingConstant.Internal.previousNotiflyUserID: try? getNotiflyUserID()
+            TrackingConstant.Internal.previousNotiflyUserID: try? getNotiflyUserID(),
         ] as? [String: Any] {
             Notifly.asyncWorker.addTask { [weak self] in
                 guard let self = self else {
@@ -85,14 +86,15 @@ class UserManager {
                 }
 
                 let previousExternalUserID = externalUserID
-                changeExternalUserId(newValue: newExternalUserID)
+                self.changeExternalUserId(newValue: newExternalUserID)
                 let postProcessConfigForSyncState = constructPostProcessConfigForSyncState(
                     previousExternalUserID: previousExternalUserID,
-                    newExternalUserID: newExternalUserID)
+                    newExternalUserID: newExternalUserID
+                )
                 if shouldRequestSyncState(
                     previousExternalUserID: previousExternalUserID,
-                    newExternalUserID: newExternalUserID)
-                {
+                    newExternalUserID: newExternalUserID
+                ) {
                     notifly.inAppMessageManager.userStateManager.syncState(
                         postProcessConfig: postProcessConfigForSyncState
                     ) {
@@ -123,22 +125,29 @@ class UserManager {
             self.changeExternalUserId(newValue: nil)
 
             let postProcessConfigForSyncState = constructPostProcessConfigForSyncState(
-                previousExternalUserID: previousExternalUserID, newExternalUserID: nil)
+                previousExternalUserID: previousExternalUserID,
+                newExternalUserID: nil
+            )
             if shouldRequestSyncState(
-                previousExternalUserID: previousExternalUserID, newExternalUserID: nil)
-            {
+                previousExternalUserID: previousExternalUserID,
+                newExternalUserID: nil
+            ) {
                 notifly.inAppMessageManager.userStateManager.syncState(
                     postProcessConfig: postProcessConfigForSyncState
                 ) {
                     notifly.trackingManager.trackInternalEvent(
                         eventName: TrackingConstant.Internal.removeUserPropertiesEventName,
-                        eventParams: nil, lockAcquired: true)
+                        eventParams: nil,
+                        lockAcquired: true
+                    )
                 }
             } else {
                 notifly.inAppMessageManager.userStateManager.clear()
                 notifly.trackingManager.trackInternalEvent(
                     eventName: TrackingConstant.Internal.removeUserPropertiesEventName,
-                    eventParams: nil, lockAcquired: true)
+                    eventParams: nil,
+                    lockAcquired: true
+                )
             }
         }
     }
@@ -165,7 +174,9 @@ class UserManager {
 
         notifly.trackingManager.trackInternalEvent(
             eventName: TrackingConstant.Internal.setUserPropertiesEventName,
-            eventParams: userProperties, lockAcquired: lockAcquired)
+            eventParams: userProperties,
+            lockAcquired: lockAcquired
+        )
     }
 
     func getNotiflyUserID() throws -> String {
@@ -196,16 +207,21 @@ class UserManager {
     }
 
     private func constructPostProcessConfigForSyncState(
-        previousExternalUserID: String?, newExternalUserID: String?
+        previousExternalUserID: String?,
+        newExternalUserID: String?
     ) -> PostProcessConfigForSyncState {
         return PostProcessConfigForSyncState(
             merge: shouldMergeStateAfterSyncState(
-                previousExternalUserID: previousExternalUserID, newExternalUserID: newExternalUserID
-            ), clear: shouldClearStateAfterSyncState(newExternalUserID: newExternalUserID))
+                previousExternalUserID: previousExternalUserID,
+                newExternalUserID: newExternalUserID
+            ),
+            clear: shouldClearStateAfterSyncState(newExternalUserID: newExternalUserID)
+        )
     }
 
     private func shouldMergeStateAfterSyncState(
-        previousExternalUserID: String?, newExternalUserID _: String?
+        previousExternalUserID: String?,
+        newExternalUserID _: String?
     ) -> Bool {
         return externalUserID != nil && previousExternalUserID == nil
     }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -38,7 +38,8 @@ import UIKit
         Notifly.asyncWorker.addTask {
             main.inAppMessageManager.userStateManager.syncState(
                 postProcessConfig:
-                    PostProcessConfigForSyncState(merge: false, clear: false)
+                    PostProcessConfigForSyncState(merge: false, clear: false),
+                handleExternalUserIdMismatch: true
             ) {
                 Notifly.asyncWorker.unlock()
             }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "1.17.2"
+    static let sdkVersion: String = "1.17.3"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '1.17.2'
+  s.version          = '1.17.3'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 1.17.2
+  NOTIFLY iOS SDK : 1.17.3
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'

--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk_push_extension'
-  s.version          = '1.17.2'
+  s.version          = '1.17.3'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS Push Extension SDK : 1.17.2
+  NOTIFLY iOS Push Extension SDK : 1.17.3
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
<!--
    노티플라이 코드리뷰 규칙
    - https://www.notion.so/greyboxhq/Code-Review-b4158492767c4e5a86d5185390e1bcea
    - https://www.notion.so/greyboxhq/Code-Review-a4ca07eb7160408398bab5aeef3ea14a
    - 리뷰어는 기본 2+명을 지정해주세요.
-->
## Summary
<!--
    - PR 개요, 변경사항, 중점적으로 보아야 하는 부분 작성.
    - 셀프 머지를 해야되는 경우 사유를 작성하고 라벨을 설정해주세요.
-->
- DB의 디바이스-유저 매핑 정보와 SDK에 저장된 유저 정보가 다른 경우 DB를 Source of Truth로 하여 SDK의 external_user_id를 DB 값으로 변경합니다.
- `Notifly.initialize()` 안에서 호출되는 `syncState()`에서만 mismatch를 핸들링하도록 합니다.

## Ref
<!--
    - 연관있는 Jira Ticket 및 기타 스펙 관련 자료들 PRD, Figma, Tech spec, etc.
-->
- https://notifly-greybox.slack.com/archives/C06BNQAU2MV/p1753234420751269
- JIRA ticket : https://greyboxhq.atlassian.net/browse/NOTIFLY-

## Appendix (optional)
<!--
    - 변경사항에 대한 스크린샷, 또는 관련 링크, 자료들.
-->
- 
