### PR TITLE
feat: 인앱 팝업 캠페인 취소 조건 지원

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-02-25
+
+### Added
+
+- Support cancellation conditions for in-app message campaigns: scheduled popups can now be cancelled by subsequent events during the delay period.
+
 ## [2.2.0] - 2025-11-27
 
 ### Fixed

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/Campaign.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/Campaign.swift
@@ -21,6 +21,8 @@ struct Campaign {
     let campaignEnd: Int?
     let delay: Int
     let reEligibleCondition: NotiflyReEligibleConditionEnum.ReEligibleCondition?
+    let cancellationConditions: TriggeringConditions?
+    let cancellationEventFilters: TriggeringEventFilters?
 
     let testing: Bool
     let whitelist: [String]?
@@ -75,6 +77,8 @@ struct Campaign {
         delay = (from["delay"] as? Int) ?? 0
         reEligibleCondition = NotiflyReEligibleConditionEnum.ReEligibleCondition(
             from: from["re_eligible_condition"] as? [String: Any])
+        cancellationConditions = try? TriggeringConditions(from: from["cancellation_conditions"])
+        cancellationEventFilters = try? TriggeringEventFilters(from: from["cancellation_event_filters"])
 
         self.testing = testing
         whitelist = testing ? from["whitelist"] as? [String] : []

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
@@ -15,6 +15,7 @@ class InAppMessageManager {
     let userStateManager: UserStateManager
     private var eventListeners: [InAppMessageEventListener] = []
     private var scheduledWorkItems: [String: DispatchWorkItem] = [:]
+    private let scheduleLock = NSLock()
 
     init(owner: String?) {
         userStateManager = UserStateManager(owner: owner)
@@ -167,12 +168,22 @@ class InAppMessageManager {
             return
         }
         let campaignId = notiflyInAppMessageData.notiflyCampaignId
+        scheduleLock.lock()
         scheduledWorkItems.removeValue(forKey: campaignId)?.cancel()
+        scheduleLock.unlock()
 
-        var workItem: DispatchWorkItem!
+        var workItem: DispatchWorkItem?
         workItem = DispatchWorkItem { [weak self] in
-            guard let self = self else { return }
-            self.scheduledWorkItems.removeValue(forKey: campaignId)
+            guard let self = self, let workItem = workItem else { return }
+
+            // Only proceed if this is still the currently scheduled instance
+            self.scheduleLock.lock()
+            let isCurrent = self.scheduledWorkItems[campaignId] === workItem
+            if isCurrent {
+                self.scheduledWorkItems.removeValue(forKey: campaignId)
+            }
+            self.scheduleLock.unlock()
+            guard isCurrent else { return }
 
             // CRITICAL: DispatchWorkItem.cancel() only sets flag, block still executes
             guard !workItem.isCancelled else {
@@ -188,7 +199,7 @@ class InAppMessageManager {
             }
 
             let currentUserData = self.userStateManager.userData
-            if let reEligibleCondition = notiflyInAppMessageData.notiflyReEligibleCondition {
+            if notiflyInAppMessageData.notiflyReEligibleCondition != nil {
                 guard
                     !self.isHiddenCampaign(
                         campaignID: notiflyInAppMessageData.notiflyCampaignId,
@@ -205,7 +216,7 @@ class InAppMessageManager {
             else {
                 return
             }
-            6
+
             guard WebViewModalViewController.openedInAppMessageCount == 0 else {
                 Logger.error("Already In App Message Opened. New In App Message Ignored.")
                 return
@@ -228,18 +239,24 @@ class InAppMessageManager {
             }
         }
 
-        if notiflyInAppMessageData.deadline > DispatchTime.now() {
-            scheduledWorkItems[campaignId] = workItem
-        }
+        guard let workItem = workItem else { return }
+        scheduleLock.lock()
+        scheduledWorkItems[campaignId] = workItem
+        scheduleLock.unlock()
         DispatchQueue.main.asyncAfter(deadline: notiflyInAppMessageData.deadline, execute: workItem)
     }
 
     func getScheduledCampaignIds() -> [String] {
+        scheduleLock.lock()
+        defer { scheduleLock.unlock() }
         return Array(scheduledWorkItems.keys)
     }
 
     func descheduleInAppMessage(campaignId: String) {
-        scheduledWorkItems.removeValue(forKey: campaignId)?.cancel()
+        scheduleLock.lock()
+        let item = scheduledWorkItems.removeValue(forKey: campaignId)
+        scheduleLock.unlock()
+        item?.cancel()
     }
 
     private func checkCancellationConditions(eventName: String, eventParams: [String: Any]?) {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
@@ -14,6 +14,7 @@ import UIKit
 class InAppMessageManager {
     let userStateManager: UserStateManager
     private var eventListeners: [InAppMessageEventListener] = []
+    private var scheduledWorkItems: [String: DispatchWorkItem] = [:]
 
     init(owner: String?) {
         userStateManager = UserStateManager(owner: owner)
@@ -25,6 +26,8 @@ class InAppMessageManager {
         guard !Notifly.inAppMessageDisabled else {
             return
         }
+
+        checkCancellationConditions(eventName: eventName, eventParams: eventParams)
 
         if var campaignsToTrigger = getCampaignsShouldBeTriggered(
             eventName: eventName, eventParams: eventParams)
@@ -163,7 +166,20 @@ class InAppMessageManager {
         guard let userID = userID else {
             return
         }
-        DispatchQueue.main.asyncAfter(deadline: notiflyInAppMessageData.deadline) {
+        let campaignId = notiflyInAppMessageData.notiflyCampaignId
+        scheduledWorkItems.removeValue(forKey: campaignId)?.cancel()
+
+        var workItem: DispatchWorkItem!
+        workItem = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            self.scheduledWorkItems.removeValue(forKey: campaignId)
+
+            // CRITICAL: DispatchWorkItem.cancel() only sets flag, block still executes
+            guard !workItem.isCancelled else {
+                Logger.info("[Notifly] Cancelled campaign skipped: \(campaignId)")
+                return
+            }
+
             guard let currentUserID = try? Notifly.main.userManager.getNotiflyUserID(),
                   userID == currentUserID
             else {
@@ -210,6 +226,41 @@ class InAppMessageManager {
                 WebViewModalViewController.openedInAppMessageCount = 0
                 return
             }
+        }
+
+        if notiflyInAppMessageData.deadline > DispatchTime.now() {
+            scheduledWorkItems[campaignId] = workItem
+        }
+        DispatchQueue.main.asyncAfter(deadline: notiflyInAppMessageData.deadline, execute: workItem)
+    }
+
+    func getScheduledCampaignIds() -> [String] {
+        return Array(scheduledWorkItems.keys)
+    }
+
+    func descheduleInAppMessage(campaignId: String) {
+        scheduledWorkItems.removeValue(forKey: campaignId)?.cancel()
+    }
+
+    private func checkCancellationConditions(eventName: String, eventParams: [String: Any]?) {
+        let scheduledIds = getScheduledCampaignIds()
+        if scheduledIds.isEmpty { return }
+
+        let campaigns = userStateManager.getInAppMessageCampaigns()
+        for campaignId in scheduledIds {
+            guard let campaign = campaigns.first(where: { $0.id == campaignId }),
+                  let cancellationConditions = campaign.cancellationConditions
+            else { continue }
+
+            guard cancellationConditions.match(eventName: eventName) else { continue }
+
+            if let filters = campaign.cancellationEventFilters,
+               !TriggeringEventFilter.matchFilterCondition(
+                   filters: filters.filters, eventParams: eventParams) {
+                continue
+            }
+
+            descheduleInAppMessage(campaignId: campaignId)
         }
     }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/InAppMessageCancellationTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/InAppMessageCancellationTests.swift
@@ -1,0 +1,303 @@
+//
+//  InAppMessageCancellationTests.swift
+//  notifly-ios-sdkTests
+//
+//  Tests for in-app message cancellation feature:
+//  - Campaign parsing of cancellation_conditions and cancellation_event_filters
+//  - TriggeringConditions.match logic for cancellation events
+//  - TriggeringEventFilter.matchFilterCondition for cancellation filters
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class InAppMessageCancellationTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Returns a valid campaign dictionary with all required fields.
+    /// Optionally includes cancellation_conditions and cancellation_event_filters.
+    private func makeCampaignDict(
+        cancellationConditions: Any? = nil,
+        cancellationEventFilters: Any? = nil,
+        includeCancellationKeys: Bool = true
+    ) -> [String: Any] {
+        var dict: [String: Any] = [
+            "id": "test_campaign_1",
+            "channel": "in-app-message",
+            "status": 1,
+            "testing": false,
+            "updated_at": "2024-01-01T00:00:00Z",
+            "starts": [1704067200],
+            "end": NSNull(),
+            "delay": 10,
+            "segment_type": "condition",
+            "segment_info": [
+                "groups": [
+                    ["conditions": [
+                        [
+                            "unit": "user",
+                            "operator": "IS_NOT_NULL",
+                            "attribute": "userId",
+                            "useEventParamsAsConditionValue": false,
+                            "valueType": "TEXT",
+                            "value": ""
+                        ]
+                    ]]
+                ]
+            ],
+            "message": [
+                "html_url": "https://example.com/message",
+                "modal_properties": [
+                    "template_name": "test_template",
+                    "position": "center"
+                ]
+            ],
+            "triggering_conditions": [
+                [["type": "event_name", "operator": "=", "operand": "purchase"]]
+            ]
+        ]
+
+        if includeCancellationKeys {
+            if let conditions = cancellationConditions {
+                dict["cancellation_conditions"] = conditions
+            }
+            if let filters = cancellationEventFilters {
+                dict["cancellation_event_filters"] = filters
+            }
+        }
+
+        return dict
+    }
+
+    // MARK: - Campaign Parsing Tests
+
+    /// Verify that Campaign correctly parses cancellation_conditions from a valid dictionary.
+    func testCampaignParsesCancellationConditions() {
+        let cancellationConditions: [[[String: Any]]] = [
+            [["type": "event_name", "operator": "=", "operand": "cancel_event"]]
+        ]
+        let dict = makeCampaignDict(cancellationConditions: cancellationConditions)
+
+        let campaign = Campaign(from: dict)
+
+        XCTAssertNotNil(campaign, "Campaign should be parsed successfully from a valid dictionary")
+        XCTAssertNotNil(campaign?.cancellationConditions, "cancellationConditions should not be nil when provided in the dictionary")
+        XCTAssertEqual(campaign?.cancellationConditions?.conditions.count, 1, "There should be exactly one condition group")
+    }
+
+    /// Verify that Campaign correctly parses cancellation_event_filters from a valid dictionary.
+    func testCampaignParsesCancellationEventFilters() {
+        let cancellationConditions: [[[String: Any]]] = [
+            [["type": "event_name", "operator": "=", "operand": "cancel_event"]]
+        ]
+        let cancellationEventFilters: [[[String: Any]]] = [
+            [["key": "item_id", "operator": "=", "value": "abc", "value_type": "TEXT"]]
+        ]
+        let dict = makeCampaignDict(
+            cancellationConditions: cancellationConditions,
+            cancellationEventFilters: cancellationEventFilters
+        )
+
+        let campaign = Campaign(from: dict)
+
+        XCTAssertNotNil(campaign, "Campaign should be parsed successfully from a valid dictionary")
+        XCTAssertNotNil(campaign?.cancellationEventFilters, "cancellationEventFilters should not be nil when provided in the dictionary")
+        XCTAssertEqual(campaign?.cancellationEventFilters?.filters.count, 1, "There should be exactly one filter group")
+    }
+
+    /// Verify that Campaign sets cancellation fields to nil when they are omitted from the dictionary.
+    func testCampaignWithoutCancellationFields() {
+        let dict = makeCampaignDict(includeCancellationKeys: false)
+
+        let campaign = Campaign(from: dict)
+
+        XCTAssertNotNil(campaign, "Campaign should still parse successfully without cancellation fields")
+        XCTAssertNil(campaign?.cancellationConditions, "cancellationConditions should be nil when not provided")
+        XCTAssertNil(campaign?.cancellationEventFilters, "cancellationEventFilters should be nil when not provided")
+    }
+
+    /// Verify that Campaign sets cancellation fields to nil when they are explicitly set to NSNull().
+    func testCampaignWithNullCancellationFields() {
+        let dict = makeCampaignDict(
+            cancellationConditions: NSNull(),
+            cancellationEventFilters: NSNull()
+        )
+
+        let campaign = Campaign(from: dict)
+
+        XCTAssertNotNil(campaign, "Campaign should still parse successfully with NSNull cancellation fields")
+        XCTAssertNil(campaign?.cancellationConditions, "cancellationConditions should be nil when set to NSNull")
+        XCTAssertNil(campaign?.cancellationEventFilters, "cancellationEventFilters should be nil when set to NSNull")
+    }
+
+    // MARK: - TriggeringConditions.match Tests
+
+    /// Verify that TriggeringConditions.match returns true when the event name matches a cancellation condition.
+    func testTriggeringConditionsMatchesCancellationEvent() {
+        let conditionsData: [[[String: Any]]] = [
+            [["type": "event_name", "operator": "=", "operand": "cancel_event"]]
+        ]
+
+        let conditions = try? TriggeringConditions(from: conditionsData)
+
+        XCTAssertNotNil(conditions, "TriggeringConditions should be created successfully")
+        XCTAssertTrue(
+            conditions!.match(eventName: "cancel_event"),
+            "match should return true when the event name exactly matches the operand"
+        )
+    }
+
+    /// Verify that TriggeringConditions.match returns false when the event name does not match.
+    func testTriggeringConditionsDoesNotMatchDifferentEvent() {
+        let conditionsData: [[[String: Any]]] = [
+            [["type": "event_name", "operator": "=", "operand": "cancel_event"]]
+        ]
+
+        let conditions = try? TriggeringConditions(from: conditionsData)
+
+        XCTAssertNotNil(conditions, "TriggeringConditions should be created successfully")
+        XCTAssertFalse(
+            conditions!.match(eventName: "purchase"),
+            "match should return false when the event name does not match the operand"
+        )
+        XCTAssertFalse(
+            conditions!.match(eventName: "cancel_event_extra"),
+            "match should return false for a partial/extended event name"
+        )
+        XCTAssertFalse(
+            conditions!.match(eventName: ""),
+            "match should return false for an empty event name"
+        )
+    }
+
+    /// Verify that TriggeringConditions.match works correctly when there are multiple condition groups (OR logic between groups).
+    func testTriggeringConditionsMatchesMultipleGroups() {
+        let conditionsData: [[[String: Any]]] = [
+            [["type": "event_name", "operator": "=", "operand": "cancel_event_a"]],
+            [["type": "event_name", "operator": "=", "operand": "cancel_event_b"]]
+        ]
+
+        let conditions = try? TriggeringConditions(from: conditionsData)
+
+        XCTAssertNotNil(conditions, "TriggeringConditions should be created successfully with multiple groups")
+        XCTAssertTrue(
+            conditions!.match(eventName: "cancel_event_a"),
+            "match should return true for the first condition group"
+        )
+        XCTAssertTrue(
+            conditions!.match(eventName: "cancel_event_b"),
+            "match should return true for the second condition group"
+        )
+        XCTAssertFalse(
+            conditions!.match(eventName: "unrelated_event"),
+            "match should return false for an event not in any condition group"
+        )
+    }
+
+    // MARK: - TriggeringEventFilter.matchFilterCondition Tests
+
+    /// Verify that TriggeringEventFilter.matchFilterCondition returns true when event params match the filter.
+    func testTriggeringEventFilterMatchesParams() {
+        let filterData: [[[String: Any]]] = [
+            [["key": "item_id", "operator": "=", "value": "abc", "value_type": "TEXT"]]
+        ]
+        let filters = try? TriggeringEventFilters(from: filterData)
+
+        XCTAssertNotNil(filters, "TriggeringEventFilters should be created successfully")
+
+        let eventParams: [String: Any] = ["item_id": "abc"]
+        let result = TriggeringEventFilter.matchFilterCondition(
+            filters: filters!.filters,
+            eventParams: eventParams
+        )
+
+        XCTAssertTrue(result, "matchFilterCondition should return true when event params match the filter")
+    }
+
+    /// Verify that TriggeringEventFilter.matchFilterCondition returns false when event params do not match the filter.
+    func testTriggeringEventFilterDoesNotMatchDifferentParams() {
+        let filterData: [[[String: Any]]] = [
+            [["key": "item_id", "operator": "=", "value": "abc", "value_type": "TEXT"]]
+        ]
+        let filters = try? TriggeringEventFilters(from: filterData)
+
+        XCTAssertNotNil(filters, "TriggeringEventFilters should be created successfully")
+
+        let eventParamsDifferentValue: [String: Any] = ["item_id": "xyz"]
+        XCTAssertFalse(
+            TriggeringEventFilter.matchFilterCondition(
+                filters: filters!.filters,
+                eventParams: eventParamsDifferentValue
+            ),
+            "matchFilterCondition should return false when the param value does not match"
+        )
+
+        let eventParamsMissingKey: [String: Any] = ["other_key": "abc"]
+        XCTAssertFalse(
+            TriggeringEventFilter.matchFilterCondition(
+                filters: filters!.filters,
+                eventParams: eventParamsMissingKey
+            ),
+            "matchFilterCondition should return false when the expected key is missing from params"
+        )
+
+        XCTAssertFalse(
+            TriggeringEventFilter.matchFilterCondition(
+                filters: filters!.filters,
+                eventParams: nil
+            ),
+            "matchFilterCondition should return false when eventParams is nil"
+        )
+
+        XCTAssertFalse(
+            TriggeringEventFilter.matchFilterCondition(
+                filters: filters!.filters,
+                eventParams: [:]
+            ),
+            "matchFilterCondition should return false when eventParams is empty"
+        )
+    }
+
+    /// Verify that TriggeringEventFilter.matchFilterCondition works with multiple filter groups (OR logic between groups).
+    func testTriggeringEventFilterMatchesWithMultipleFilterGroups() {
+        let filterData: [[[String: Any]]] = [
+            [["key": "item_id", "operator": "=", "value": "abc", "value_type": "TEXT"]],
+            [["key": "category", "operator": "=", "value": "electronics", "value_type": "TEXT"]]
+        ]
+        let filters = try? TriggeringEventFilters(from: filterData)
+
+        XCTAssertNotNil(filters, "TriggeringEventFilters should be created successfully with multiple groups")
+
+        // Matches first group
+        let paramsMatchFirst: [String: Any] = ["item_id": "abc"]
+        XCTAssertTrue(
+            TriggeringEventFilter.matchFilterCondition(
+                filters: filters!.filters,
+                eventParams: paramsMatchFirst
+            ),
+            "matchFilterCondition should return true when params match the first filter group"
+        )
+
+        // Matches second group
+        let paramsMatchSecond: [String: Any] = ["category": "electronics"]
+        XCTAssertTrue(
+            TriggeringEventFilter.matchFilterCondition(
+                filters: filters!.filters,
+                eventParams: paramsMatchSecond
+            ),
+            "matchFilterCondition should return true when params match the second filter group"
+        )
+
+        // Matches neither group
+        let paramsMatchNeither: [String: Any] = ["item_id": "xyz", "category": "clothing"]
+        XCTAssertFalse(
+            TriggeringEventFilter.matchFilterCondition(
+                filters: filters!.filters,
+                eventParams: paramsMatchNeither
+            ),
+            "matchFilterCondition should return false when params match neither filter group"
+        )
+    }
+}

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '2.2.0'
+  s.version          = '2.3.0'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 2.2.0
+  NOTIFLY iOS SDK : 2.3.0
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary
- Campaign 모델에 `cancellationConditions`, `cancellationEventFilters` 필드 추가
- `DispatchWorkItem` 기반 취소 가능한 스케줄링으로 전환
- 이벤트 발생 시 스케줄된 캠페인의 취소 조건 평가 및 deschedule 로직 추가
- 취소 조건 관련 유닛 테스트 10개 추가

## Ref
- https://linear.app/greyboxhq/issue/NOTIFLY-459/인앱-팝업-캠페인에-취소-조건을-세팅할-수-있다

## Test plan
- [x] 유닛 테스트 통과 (10/10)
- [x] 디바이스 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인앱 메시지 캠페인에 이벤트 기반 취소 조건 및 이벤트 필터 지원 추가
  * 캠페인별 예약(스케줄링) 관리 및 개별 취소 제어 도입

* **버그 수정 / 개선**
  * 예약된 캠페인에 대해 취소 조건 검사 및 중복 예약 방지 등 안정성 향상

* **테스트**
  * 취소 조건·필터의 파싱 및 매칭을 검증하는 포괄적 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->