### PR TITLE
chore: bump push extension version to 2.3.0

### DIFF
--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk_push_extension'
-  s.version          = '2.2.0'
+  s.version          = '2.3.0'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS Push Extension SDK : 2.2.0
+  NOTIFLY iOS Push Extension SDK : 2.3.0
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary
- `notifly_sdk_push_extension` 버전을 2.3.0으로 업데이트 (notifly_sdk 2.3.0과 동기화)

## Ref
- NOTIFLY-459