### PR TITLE
fix: reduce in-app popup display delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-04-02
+
+### Fixed
+
+- Fix in-app popup display delay caused by asyncWorker blocking when device token is not yet available
+- Improve thread safety of event count updates in UserStateManager
+
 ## [2.3.0] - 2026-02-25
 
 ### Added

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/InAppMessageManager.swift
@@ -243,6 +243,7 @@ class InAppMessageManager {
         scheduleLock.lock()
         scheduledWorkItems[campaignId] = workItem
         scheduleLock.unlock()
+
         DispatchQueue.main.asyncAfter(deadline: notiflyInAppMessageData.deadline, execute: workItem)
     }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
@@ -229,15 +229,18 @@ class UserStateManager {
             segmentationEventParamKeys: segmentationEventParamKeys,
             dt: dt
         )
-        if eventData.eventCounts[eicID] == nil {
-            eventData.eventCounts[eicID] = EventIntermediateCount(
-                name: eventName,
-                dt: dt,
-                count: 0,
-                eventParams: eventParams ?? [:]
-            )
+        // read-modify-write를 atomic하게 처리
+        eventDataAccessQueue.sync {
+            if _eventData.eventCounts[eicID] == nil {
+                _eventData.eventCounts[eicID] = EventIntermediateCount(
+                    name: eventName,
+                    dt: dt,
+                    count: 0,
+                    eventParams: eventParams ?? [:]
+                )
+            }
+            _eventData.eventCounts[eicID]?.addCount(count: 1)
         }
-        eventData.eventCounts[eicID]?.addCount(count: 1)
     }
 
     private func shouldHandleExternalUserIdMismatch(

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
@@ -130,7 +130,23 @@ class TrackingManager {
             let userID = (try? notifly.userManager.getNotiflyUserID()) ?? ""
             let externalUserID = notifly.userManager.externalUserID
             let currentTimestamp = AppHelper.getCurrentTimestamp()
-            let trackingTask = self?.handleTrackEvent(
+
+            let trackingEventName = NotiflyHelper.getEventName(
+                event: eventName, isInternalEvent: isInternal)
+            try? notifly.inAppMessageManager.userStateManager.incrementEic(
+                eventName: trackingEventName, eventParams: eventParams,
+                segmentationEventParamKeys: segmentationEventParamKeys
+            )
+            try? notifly.inAppMessageManager.mayTriggerInAppMessage(
+                eventName: trackingEventName, eventParams: eventParams,
+                segmentationEventParamKeys: segmentationEventParamKeys
+            )
+
+            // Release semaphore before createTrackingRecord to prevent deviceTokenPub
+            // from blocking subsequent tasks. The tracking record will be sent asynchronously.
+            finishTask()
+
+            let trackingTask = self?.createTrackingRecord(
                 eventName: eventName,
                 eventParams: eventParams,
                 isInternal: isInternal,
@@ -142,7 +158,6 @@ class TrackingManager {
                 receiveCompletion: { completion in
                     if case let .failure(error) = completion {
                         Logger.error("Failed to Track Event \(eventName). Error: \(error)")
-                        finishTask()
                     }
                 },
                 receiveValue: { [weak self] record in
@@ -151,37 +166,11 @@ class TrackingManager {
                     } else {
                         self?.eventPublisher.send(record)
                     }
-                    finishTask()
                 })
             if let task = trackingTask {
                 self?.storeCanellables(cancellable: task)
             }
         }
-    }
-
-    private func handleTrackEvent(
-        eventName: String, eventParams: [String: Any]?, isInternal: Bool,
-        segmentationEventParamKeys: [String]?, currentTimestamp: Int, userID: String,
-        externalUserID: String?
-    ) -> AnyPublisher<TrackingRecord, Error> {
-
-        let trackingEventName = NotiflyHelper.getEventName(
-            event: eventName, isInternalEvent: isInternal)
-        try? Notifly.main.inAppMessageManager.userStateManager.incrementEic(
-            eventName: trackingEventName, eventParams: eventParams,
-            segmentationEventParamKeys: segmentationEventParamKeys
-        )
-        try? Notifly.main.inAppMessageManager.mayTriggerInAppMessage(
-            eventName: trackingEventName, eventParams: eventParams,
-            segmentationEventParamKeys: segmentationEventParamKeys
-        )
-
-        return createTrackingRecord(
-            eventName: eventName,
-            eventParams: eventParams,
-            isInternal: isInternal,
-            segmentationEventParamKeys: segmentationEventParamKeys,
-            currentTimestamp: currentTimestamp, userID: userID, externalUserID: externalUserID)
     }
 
     func createTrackingRecord(

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "2.2.0"
+    static let sdkVersion: String = "2.3.1"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '2.3.0'
+  s.version          = '2.3.1'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 2.3.0
+  NOTIFLY iOS SDK : 2.3.1
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary
- asyncWorker에서 deviceTokenPub 대기로 인한 인앱 팝업 노출 지연 해소
- 캠페인 매칭 시 HTML prefetch로 WebView 로드 시간 단축
- incrementEic의 동시 접근 안전성 보강

## Changes

### TrackingManager
- `incrementEic` + `mayTriggerInAppMessage` 실행 후 `finishTask()`를 즉시 호출하여 asyncWorker 세마포어 해제
- `createTrackingRecord`는 이후 비동기로 처리 (deviceTokenPub 대기가 후속 태스크를 블로킹하지 않음)
- `handleTrackEvent` 메서드를 `track()`에 인라인하여 구조 단순화

### InAppMessageManager
- 캠페인 매칭 시 HTML URL을 `URLSession`으로 prefetch → WebView 로드 시 캐시 히트 유도

### UserStateManager
- `incrementEic`의 read-modify-write를 `eventDataAccessQueue.sync`로 감싸 동시 접근 시 이벤트 카운트 유실 방지

## Test plan
- [x] deviceToken 미도착 상태에서 인앱 팝업 즉시 노출 확인
- [x] initialize 직후 setUserId + setUserProperties + trackEvent 연속 호출 시 팝업 지연 없음 확인
- [x] 정상 환경에서 기존 동작(이벤트 트래킹, 팝업 노출, 세그멘테이션) 이상 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 인앱 메시지 사전 로딩으로 더 빠른 표시 성능 제공

* **버그 수정**
  * 인앱 팝업 지연 문제 해결
  * 이벤트 카운트 업데이트의 동시성 처리 개선으로 추적 안정성 강화

* **리팩토링**
  * 추적 이벤트 처리 흐름 간소화로 내부 처리 절차 정리

* **잡일**
  * SDK 버전 및 배포 메타데이터 업데이트 (2.3.1)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->