### PR TITLE
feat: 인앱 메시지 링크 내부 브라우저 모드 지원

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0] - 2026-04-14
+
+### Added
+
+- Support in-app browser mode for in-app message links: add `?nf_open_mode=in_app_browser` to open URLs in SFSafariViewController instead of an external browser.
+- Automatic Universal Link detection via Mach-O entitlements parsing: URLs matching the app's associated domains are forwarded to the app's deep link handler via NSUserActivity.
+
 ## [2.3.1] - 2026-04-02
 
 ### Fixed

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		F2E669982ADE602900DF9CA0 /* TrackingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6698C2ADE602900DF9CA0 /* TrackingManager.swift */; };
 		F2E669992ADE602900DF9CA0 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6698E2ADE602900DF9CA0 /* UserManager.swift */; };
 		F2E6699A2ADE60A600DF9CA0 /* AppHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669762ADE5FD000DF9CA0 /* AppHelper.swift */; };
+		AA00000000000001 /* NotiflyLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000002 /* NotiflyLinkHelper.swift */; };
+		AA00000000000003 /* ApplicationBinary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000004 /* ApplicationBinary.swift */; };
+		AA00000000000005 /* EntitlementsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000006 /* EntitlementsReader.swift */; };
 		F2E6699B2ADE60AA00DF9CA0 /* Notifly.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669772ADE5FD000DF9CA0 /* Notifly.swift */; };
 		F2E6699C2ADE60AD00DF9CA0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */; };
 		F2E6699D2ADE60AF00DF9CA0 /* NotiflyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */; };
@@ -73,6 +76,9 @@
 		F2E669732ADE5F7E00DF9CA0 /* UUID+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UUID+.swift"; sourceTree = "<group>"; };
 		F2E669742ADE5F7E00DF9CA0 /* TrackingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEvent.swift; sourceTree = "<group>"; };
 		F2E669762ADE5FD000DF9CA0 /* AppHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHelper.swift; sourceTree = "<group>"; };
+		AA00000000000002 /* NotiflyLinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelper.swift; sourceTree = "<group>"; };
+		AA00000000000004 /* ApplicationBinary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBinary.swift; sourceTree = "<group>"; };
+		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
 		F2E669772ADE5FD000DF9CA0 /* Notifly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifly.swift; sourceTree = "<group>"; };
 		F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotiflyExtensionAPI.swift; sourceTree = "<group>"; };
 		F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationServiceExtension.swift; sourceTree = "<group>"; };
@@ -161,11 +167,22 @@
 			path = SourceCodes;
 			sourceTree = "<group>";
 		};
+		AA00000000000007 /* Entitlements */ = {
+			isa = PBXGroup;
+			children = (
+				AA00000000000004 /* ApplicationBinary.swift */,
+				AA00000000000006 /* EntitlementsReader.swift */,
+			);
+			path = Entitlements;
+			sourceTree = "<group>";
+		};
 		F2E6696C2ADE5F7E00DF9CA0 /* NotiflyUtil */ = {
 			isa = PBXGroup;
 			children = (
 				2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */,
 				F2E669762ADE5FD000DF9CA0 /* AppHelper.swift */,
+				AA00000000000002 /* NotiflyLinkHelper.swift */,
+				AA00000000000007 /* Entitlements */,
 				F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */,
 				F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */,
 				F2E6696F2ADE5F7E00DF9CA0 /* Logger.swift */,
@@ -407,6 +424,9 @@
 				F2E6698F2ADE602900DF9CA0 /* NotificationsManager.swift in Sources */,
 				F2E669922ADE602900DF9CA0 /* InAppMessageManager.swift in Sources */,
 				F2E6699A2ADE60A600DF9CA0 /* AppHelper.swift in Sources */,
+				AA00000000000001 /* NotiflyLinkHelper.swift in Sources */,
+				AA00000000000003 /* ApplicationBinary.swift in Sources */,
+				AA00000000000005 /* EntitlementsReader.swift in Sources */,
 				F2E669952ADE602900DF9CA0 /* WebViewModalViewController.swift in Sources */,
 				F2E92DA12B4DC6FD00EAB6AB /* SegmentationHelper.swift in Sources */,
 				F2E6697B2ADE600000DF9CA0 /* NotiflyExtensionAPI.swift in Sources */,

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */; };
 		673F0E8B29EBA7D200814217 /* notifly_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */; };
 		673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */; };
+		AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000011 /* NotiflyLinkHelperTests.swift */; };
 		673F0EBB29EC610400814217 /* Notifly+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */; };
 		B0521E422C1B572100D4E357 /* Timezone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0521E412C1B572100D4E357 /* Timezone.swift */; };
 		F2E6697B2ADE600000DF9CA0 /* NotiflyExtensionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */; };
@@ -65,6 +66,7 @@
 		673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = notifly_ios_sdk.docc; sourceTree = "<group>"; };
 		673F0E8A29EBA7D200814217 /* notifly-ios-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "notifly-ios-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notifly_ios_sdkTests.swift; sourceTree = "<group>"; };
+		AA00000000000011 /* NotiflyLinkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelperTests.swift; sourceTree = "<group>"; };
 		673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notifly+PublicAPI.swift"; sourceTree = "<group>"; };
 		B0521E412C1B572100D4E357 /* Timezone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timezone.swift; sourceTree = "<group>"; };
 		F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -152,6 +154,7 @@
 			isa = PBXGroup;
 			children = (
 				673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */,
+				AA00000000000011 /* NotiflyLinkHelperTests.swift */,
 			);
 			path = "notifly-ios-sdkTests";
 			sourceTree = "<group>";
@@ -441,6 +444,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */,
+				AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
@@ -232,7 +232,10 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                         eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
                         eventParams: paramsWithLink)
 
-                    if openMode == "in_app_browser" {
+                    let scheme = cleanURL.scheme?.lowercased()
+                    if openMode == "in_app_browser",
+                       scheme == "http" || scheme == "https"
+                    {
                         let presenter = self.presentingViewController
                         dismissCTATapped {
                             let safariVC = SFSafariViewController(url: cleanURL)

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
@@ -220,8 +220,8 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                 if let urlString = messageEventData["link"] as? String,
                    let url = URL(string: urlString)
                 {
-                    let openMode = Self.parseOpenMode(from: url)
-                    let cleanURL = Self.stripNotiflyParams(from: url)
+                    let openMode = NotiflyLinkHelper.parseOpenMode(from: url)
+                    let cleanURL = NotiflyLinkHelper.stripNotiflyParams(from: url)
                     var paramsWithLink = params
                     paramsWithLink["link"] = cleanURL.absoluteString
 
@@ -236,10 +236,15 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                     if openMode == "in_app_browser",
                        scheme == "http" || scheme == "https"
                     {
-                        let presenter = self.presentingViewController
-                        dismissCTATapped {
-                            let safariVC = SFSafariViewController(url: cleanURL)
-                            presenter?.present(safariVC, animated: true)
+                        if NotiflyLinkHelper.isOwnUniversalLink(cleanURL) {
+                            NotiflyLinkHelper.openAsUniversalLink(cleanURL)
+                            dismissCTATapped()
+                        } else {
+                            let presenter = self.presentingViewController
+                            dismissCTATapped {
+                                let safariVC = SFSafariViewController(url: cleanURL)
+                                presenter?.present(safariVC, animated: true)
+                            }
                         }
                     } else {
                         UIApplication.shared.open(cleanURL)
@@ -290,23 +295,6 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                 return
             }
         }
-    }
-
-    // MARK: - Link Open Mode Helpers
-
-    private static let nfOpenModeParam = "nf_open_mode"
-
-    private static func parseOpenMode(from url: URL) -> String? {
-        URLComponents(url: url, resolvingAgainstBaseURL: false)?
-            .queryItems?.first(where: { $0.name == nfOpenModeParam })?.value
-    }
-
-    private static func stripNotiflyParams(from url: URL) -> URL {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        else { return url }
-        components.queryItems = components.queryItems?.filter { $0.name != nfOpenModeParam }
-        if components.queryItems?.isEmpty == true { components.queryItems = nil }
-        return components.url ?? url
     }
 
     private func getModalSize() -> CGSize? {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
@@ -240,15 +240,19 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                     if openMode == "in_app_browser",
                        scheme == "http" || scheme == "https"
                     {
+                        // Universal Link → 앱 딥링크 핸들러로 직접 전달 시도
                         if NotiflyLinkHelper.isOwnUniversalLink(cleanURL) {
-                            NotiflyLinkHelper.openAsUniversalLink(cleanURL)
-                            dismissCTATapped()
-                        } else {
-                            let presenter = self.presentingViewController
-                            dismissInAppMessage {
-                                let safariVC = SFSafariViewController(url: cleanURL)
-                                presenter?.present(safariVC, animated: true)
+                            let currentScene = self.view.window?.windowScene
+                            if NotiflyLinkHelper.openAsUniversalLink(cleanURL, in: currentScene) {
+                                dismissCTATapped()
+                                break
                             }
+                        }
+                        // 외부 URL 또는 Universal Link fallback → SFSafariViewController
+                        let presenter = self.presentingViewController
+                        dismissInAppMessage {
+                            let safariVC = SFSafariViewController(url: cleanURL)
+                            presenter?.present(safariVC, animated: true)
                         }
                     } else {
                         UIApplication.shared.open(cleanURL)

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
@@ -116,9 +116,11 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
     }
 
     @objc
-    private func dismissCTATapped() {
-        dismiss(animated: false)
-        WebViewModalViewController.openedInAppMessageCount = 0
+    private func dismissCTATapped(completion: (() -> Void)? = nil) {
+        dismiss(animated: false) {
+            WebViewModalViewController.openedInAppMessageCount = 0
+            completion?()
+        }
     }
 
     func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
@@ -223,20 +225,23 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                     var paramsWithLink = params
                     paramsWithLink["link"] = cleanURL.absoluteString
 
-                    if openMode == "in_app_browser" {
-                      let safariVC = SFSafariViewController(url: cleanURL)
-                      self.present(safariVC, animated: true)
-                    } else {
-                        UIApplication.shared.open(cleanURL)
-                    }
-
                     notifly.trackingManager.trackInternalEvent(
                         eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
                         eventParams: paramsWithLink)
                     notifly.inAppMessageManager.dispatchInAppMessageEvent(
                         eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
                         eventParams: paramsWithLink)
-                    dismissCTATapped()
+
+                    if openMode == "in_app_browser" {
+                        let presenter = self.presentingViewController
+                        dismissCTATapped {
+                            let safariVC = SFSafariViewController(url: cleanURL)
+                            presenter?.present(safariVC, animated: true)
+                        }
+                    } else {
+                        UIApplication.shared.open(cleanURL)
+                        dismissCTATapped()
+                    }
                 } else {
                     notifly.trackingManager.trackInternalEvent(
                         eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SafariServices
 import UIKit
 import WebKit
 
@@ -217,17 +218,25 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                 if let urlString = messageEventData["link"] as? String,
                    let url = URL(string: urlString)
                 {
-                    UIApplication.shared.open(url, options: [:]) { _ in
-                        var paramsWithLink = params
-                        paramsWithLink["link"] = urlString
-                        notifly.trackingManager.trackInternalEvent(
-                            eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
-                            eventParams: paramsWithLink)
-                        notifly.inAppMessageManager.dispatchInAppMessageEvent(
-                            eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
-                            eventParams: paramsWithLink)
-                        self.dismissCTATapped()
+                    let openMode = Self.parseOpenMode(from: url)
+                    let cleanURL = Self.stripNotiflyParams(from: url)
+                    var paramsWithLink = params
+                    paramsWithLink["link"] = cleanURL.absoluteString
+
+                    if openMode == "in_app_browser" {
+                      let safariVC = SFSafariViewController(url: cleanURL)
+                      self.present(safariVC, animated: true)
+                    } else {
+                        UIApplication.shared.open(cleanURL)
                     }
+
+                    notifly.trackingManager.trackInternalEvent(
+                        eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
+                        eventParams: paramsWithLink)
+                    notifly.inAppMessageManager.dispatchInAppMessageEvent(
+                        eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
+                        eventParams: paramsWithLink)
+                    dismissCTATapped()
                 } else {
                     notifly.trackingManager.trackInternalEvent(
                         eventName: TrackingConstant.Internal.inAppMessageMainButtonClicked,
@@ -273,6 +282,23 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                 return
             }
         }
+    }
+
+    // MARK: - Link Open Mode Helpers
+
+    private static let nfOpenModeParam = "nf_open_mode"
+
+    private static func parseOpenMode(from url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == nfOpenModeParam })?.value
+    }
+
+    private static func stripNotiflyParams(from url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return url }
+        components.queryItems = components.queryItems?.filter { $0.name != nfOpenModeParam }
+        if components.queryItems?.isEmpty == true { components.queryItems = nil }
+        return components.url ?? url
     }
 
     private func getModalSize() -> CGSize? {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/WebViewModalViewController.swift
@@ -116,7 +116,11 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
     }
 
     @objc
-    private func dismissCTATapped(completion: (() -> Void)? = nil) {
+    private func dismissCTATapped() {
+        dismissInAppMessage()
+    }
+
+    private func dismissInAppMessage(completion: (() -> Void)? = nil) {
         dismiss(animated: false) {
             WebViewModalViewController.openedInAppMessageCount = 0
             completion?()
@@ -241,7 +245,7 @@ class WebViewModalViewController: UIViewController, WKNavigationDelegate, WKScri
                             dismissCTATapped()
                         } else {
                             let presenter = self.presentingViewController
-                            dismissCTATapped {
+                            dismissInAppMessage {
                                 let safariVC = SFSafariViewController(url: cleanURL)
                                 presenter?.present(safariVC, animated: true)
                             }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "2.3.1"
+    static let sdkVersion: String = "2.4.0"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/ApplicationBinary.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/ApplicationBinary.swift
@@ -1,0 +1,33 @@
+/// Mach-O 바이너리 파일을 읽기 위한 FileHandle 래퍼.
+/// Reference: https://github.com/matrejek/SwiftEntitlements
+import Foundation
+
+class ApplicationBinary {
+
+    private let handle: FileHandle
+
+    init?(_ path: String) {
+        guard let binaryHandle = FileHandle(forReadingAtPath: path) else {
+            return nil
+        }
+        handle = binaryHandle
+    }
+
+    var currentOffset: UInt64 { handle.offsetInFile }
+
+    func seek(to offset: UInt64) {
+        handle.seek(toFileOffset: offset)
+    }
+
+    func read<T>() -> T {
+        handle.readData(ofLength: MemoryLayout<T>.size).withUnsafeBytes { $0.load(as: T.self) }
+    }
+
+    func readData(ofLength length: Int) -> Data {
+        handle.readData(ofLength: length)
+    }
+
+    deinit {
+        handle.closeFile()
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/ApplicationBinary.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/ApplicationBinary.swift
@@ -19,8 +19,10 @@ class ApplicationBinary {
         handle.seek(toFileOffset: offset)
     }
 
-    func read<T>() -> T {
-        handle.readData(ofLength: MemoryLayout<T>.size).withUnsafeBytes { $0.load(as: T.self) }
+    func read<T>() -> T? {
+        let data = handle.readData(ofLength: MemoryLayout<T>.size)
+        guard data.count == MemoryLayout<T>.size else { return nil }
+        return data.withUnsafeBytes { $0.load(as: T.self) }
     }
 
     func readData(ofLength length: Int) -> Data {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/EntitlementsReader.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/EntitlementsReader.swift
@@ -88,18 +88,28 @@ class EntitlementsReader {
         binary.seek(to: UInt64(offset))
         for _ in 0..<cmdCount {
             guard let command: load_command = binary.read() else { break }
+            guard command.cmdsize >= UInt32(MemoryLayout<load_command>.size) else { break }
             if command.cmd == LC_CODE_SIGNATURE {
-                guard let signatureOffset: UInt32 = binary.read() else {
+                guard let sigOffset: UInt32 = binary.read() else {
                     throw Error.signatureReadingError
                 }
-                return try readEntitlementsFromSignature(startingAt: signatureOffset)
+                guard let sigSize: UInt32 = binary.read() else {
+                    throw Error.signatureReadingError
+                }
+                return try readEntitlementsFromSignature(
+                    startingAt: sigOffset,
+                    signatureSize: sigSize
+                )
             }
-            binary.seek(to: binary.currentOffset + UInt64(command.cmdsize - UInt32(MemoryLayout<load_command>.size)))
+            let skip = UInt64(command.cmdsize) - UInt64(MemoryLayout<load_command>.size)
+            binary.seek(to: binary.currentOffset + skip)
         }
         throw Error.codeSignatureCommandMissing
     }
 
-    private func readEntitlementsFromSignature(startingAt offset: UInt32) throws -> [String: Any] {
+    private func readEntitlementsFromSignature(startingAt offset: UInt32, signatureSize: UInt32) throws -> [String: Any] {
+        let sigEnd = UInt64(offset) + UInt64(signatureSize)
+
         binary.seek(to: UInt64(offset))
         guard let metaBlob: CSSuperBlob = binary.read() else {
             throw Error.signatureReadingError
@@ -108,21 +118,41 @@ class EntitlementsReader {
             throw Error.signatureReadingError
         }
 
+        let superBlobLength = CFSwapInt32(metaBlob.length)
+        guard superBlobLength <= signatureSize else {
+            throw Error.signatureReadingError
+        }
+
         let metaBlobSize = UInt32(MemoryLayout<CSSuperBlob>.size)
         let blobSize = UInt32(MemoryLayout<CSBlob>.size)
         let itemCount = CFSwapInt32(metaBlob.count)
 
         for index in 0..<itemCount {
-            binary.seek(to: UInt64(offset + metaBlobSize + index * blobSize))
+            let entryPos = UInt64(offset + metaBlobSize + index * blobSize)
+            guard entryPos + UInt64(blobSize) <= sigEnd else { continue }
+
+            binary.seek(to: entryPos)
             guard let blob: CSBlob = binary.read() else { continue }
-            binary.seek(to: UInt64(offset + CFSwapInt32(blob.offset)))
+
+            let blobOffset = CFSwapInt32(blob.offset)
+            let blobPos = UInt64(offset) + UInt64(blobOffset)
+            guard blobPos + 8 <= sigEnd else { continue }
+
+            binary.seek(to: blobPos)
             guard let blobMagicRaw: UInt32 = binary.read() else { continue }
             let blobMagic = CFSwapInt32(blobMagicRaw)
+
             if blobMagic == CSMagic.embeddedEntitlements {
                 guard let lengthRaw: UInt32 = binary.read() else { continue }
                 let length = Int(CFSwapInt32(lengthRaw))
                 guard length > 8 else { continue }
-                let data = binary.readData(ofLength: length - 8)
+
+                let dataLength = length - 8
+                guard blobPos + UInt64(length) <= sigEnd else { continue }
+
+                let data = binary.readData(ofLength: dataLength)
+                guard data.count == dataLength else { continue }
+
                 if let plist = try? PropertyListSerialization.propertyList(
                     from: data, options: [], format: nil
                 ) as? [String: Any] {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/EntitlementsReader.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/EntitlementsReader.swift
@@ -64,7 +64,7 @@ class EntitlementsReader {
 
     private func getBinaryType(fromSliceStartingAt offset: UInt64 = 0) -> BinaryType? {
         binary.seek(to: offset)
-        let header: mach_header = binary.read()
+        guard let header: mach_header = binary.read() else { return nil }
         let commandCount = Int(header.ncmds)
         switch header.magic {
         case MH_MAGIC:
@@ -79,7 +79,7 @@ class EntitlementsReader {
             ))
         default:
             binary.seek(to: 0)
-            let fatHeader: fat_header = binary.read()
+            guard let fatHeader: fat_header = binary.read() else { return nil }
             return CFSwapInt32(fatHeader.magic) == FAT_MAGIC ? .fat(header: fatHeader) : nil
         }
     }
@@ -87,9 +87,11 @@ class EntitlementsReader {
     private func readEntitlementsFromBinarySlice(startingAt offset: Int, cmdCount: Int) throws -> [String: Any] {
         binary.seek(to: UInt64(offset))
         for _ in 0..<cmdCount {
-            let command: load_command = binary.read()
+            guard let command: load_command = binary.read() else { break }
             if command.cmd == LC_CODE_SIGNATURE {
-                let signatureOffset: UInt32 = binary.read()
+                guard let signatureOffset: UInt32 = binary.read() else {
+                    throw Error.signatureReadingError
+                }
                 return try readEntitlementsFromSignature(startingAt: signatureOffset)
             }
             binary.seek(to: binary.currentOffset + UInt64(command.cmdsize - UInt32(MemoryLayout<load_command>.size)))
@@ -99,7 +101,9 @@ class EntitlementsReader {
 
     private func readEntitlementsFromSignature(startingAt offset: UInt32) throws -> [String: Any] {
         binary.seek(to: UInt64(offset))
-        let metaBlob: CSSuperBlob = binary.read()
+        guard let metaBlob: CSSuperBlob = binary.read() else {
+            throw Error.signatureReadingError
+        }
         guard CFSwapInt32(metaBlob.magic) == CSMagic.embeddedSignature else {
             throw Error.signatureReadingError
         }
@@ -110,12 +114,15 @@ class EntitlementsReader {
 
         for index in 0..<itemCount {
             binary.seek(to: UInt64(offset + metaBlobSize + index * blobSize))
-            let blob: CSBlob = binary.read()
+            guard let blob: CSBlob = binary.read() else { continue }
             binary.seek(to: UInt64(offset + CFSwapInt32(blob.offset)))
-            let blobMagic: UInt32 = CFSwapInt32(binary.read())
+            guard let blobMagicRaw: UInt32 = binary.read() else { continue }
+            let blobMagic = CFSwapInt32(blobMagicRaw)
             if blobMagic == CSMagic.embeddedEntitlements {
-                let length: UInt32 = CFSwapInt32(binary.read())
-                let data = binary.readData(ofLength: Int(length) - 8)
+                guard let lengthRaw: UInt32 = binary.read() else { continue }
+                let length = Int(CFSwapInt32(lengthRaw))
+                guard length > 8 else { continue }
+                let data = binary.readData(ofLength: length - 8)
                 if let plist = try? PropertyListSerialization.propertyList(
                     from: data, options: [], format: nil
                 ) as? [String: Any] {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/EntitlementsReader.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Entitlements/EntitlementsReader.swift
@@ -1,0 +1,128 @@
+/// Mach-O 바이너리의 코드 서명에서 entitlements plist를 추출합니다.
+/// Reference: https://github.com/matrejek/SwiftEntitlements
+import Foundation
+import MachO
+
+class EntitlementsReader {
+
+    enum Error: Swift.Error {
+        case binaryOpeningError
+        case unknownBinaryFormat
+        case codeSignatureCommandMissing
+        case signatureReadingError
+        case unsupportedFatBinary
+    }
+
+    private struct CSSuperBlob {
+        var magic: UInt32
+        var length: UInt32
+        var count: UInt32
+    }
+
+    private struct CSBlob {
+        var type: UInt32
+        var offset: UInt32
+    }
+
+    private struct CSMagic {
+        static let embeddedSignature: UInt32 = 0xfade0cc0
+        static let embeddedEntitlements: UInt32 = 0xfade7171
+    }
+
+    private struct BinaryHeaderData {
+        let headerSize: Int
+        let commandCount: Int
+    }
+
+    private enum BinaryType {
+        case singleArch(headerInfo: BinaryHeaderData)
+        case fat(header: fat_header)
+    }
+
+    private let binary: ApplicationBinary
+
+    init(_ binaryPath: String) throws {
+        guard let binary = ApplicationBinary(binaryPath) else {
+            throw Error.binaryOpeningError
+        }
+        self.binary = binary
+    }
+
+    func readEntitlements() throws -> [String: Any] {
+        switch getBinaryType() {
+        case .singleArch(let headerInfo):
+            return try readEntitlementsFromBinarySlice(
+                startingAt: headerInfo.headerSize,
+                cmdCount: headerInfo.commandCount
+            )
+        case .fat:
+            throw Error.unsupportedFatBinary
+        case .none:
+            throw Error.unknownBinaryFormat
+        }
+    }
+
+    private func getBinaryType(fromSliceStartingAt offset: UInt64 = 0) -> BinaryType? {
+        binary.seek(to: offset)
+        let header: mach_header = binary.read()
+        let commandCount = Int(header.ncmds)
+        switch header.magic {
+        case MH_MAGIC:
+            return .singleArch(headerInfo: .init(
+                headerSize: MemoryLayout<mach_header>.size,
+                commandCount: commandCount
+            ))
+        case MH_MAGIC_64:
+            return .singleArch(headerInfo: .init(
+                headerSize: MemoryLayout<mach_header_64>.size,
+                commandCount: commandCount
+            ))
+        default:
+            binary.seek(to: 0)
+            let fatHeader: fat_header = binary.read()
+            return CFSwapInt32(fatHeader.magic) == FAT_MAGIC ? .fat(header: fatHeader) : nil
+        }
+    }
+
+    private func readEntitlementsFromBinarySlice(startingAt offset: Int, cmdCount: Int) throws -> [String: Any] {
+        binary.seek(to: UInt64(offset))
+        for _ in 0..<cmdCount {
+            let command: load_command = binary.read()
+            if command.cmd == LC_CODE_SIGNATURE {
+                let signatureOffset: UInt32 = binary.read()
+                return try readEntitlementsFromSignature(startingAt: signatureOffset)
+            }
+            binary.seek(to: binary.currentOffset + UInt64(command.cmdsize - UInt32(MemoryLayout<load_command>.size)))
+        }
+        throw Error.codeSignatureCommandMissing
+    }
+
+    private func readEntitlementsFromSignature(startingAt offset: UInt32) throws -> [String: Any] {
+        binary.seek(to: UInt64(offset))
+        let metaBlob: CSSuperBlob = binary.read()
+        guard CFSwapInt32(metaBlob.magic) == CSMagic.embeddedSignature else {
+            throw Error.signatureReadingError
+        }
+
+        let metaBlobSize = UInt32(MemoryLayout<CSSuperBlob>.size)
+        let blobSize = UInt32(MemoryLayout<CSBlob>.size)
+        let itemCount = CFSwapInt32(metaBlob.count)
+
+        for index in 0..<itemCount {
+            binary.seek(to: UInt64(offset + metaBlobSize + index * blobSize))
+            let blob: CSBlob = binary.read()
+            binary.seek(to: UInt64(offset + CFSwapInt32(blob.offset)))
+            let blobMagic: UInt32 = CFSwapInt32(binary.read())
+            if blobMagic == CSMagic.embeddedEntitlements {
+                let length: UInt32 = CFSwapInt32(binary.read())
+                let data = binary.readData(ofLength: Int(length) - 8)
+                if let plist = try? PropertyListSerialization.propertyList(
+                    from: data, options: [], format: nil
+                ) as? [String: Any] {
+                    return plist
+                }
+            }
+        }
+        throw Error.signatureReadingError
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/NotiflyLinkHelper.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/NotiflyLinkHelper.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SafariServices
 import UIKit
 
 /// 인앱 메시지 링크의 open mode 파싱, URL 정제, Universal Link 처리를 담당합니다.
@@ -75,27 +74,46 @@ enum NotiflyLinkHelper {
     // MARK: - Universal Link Forwarding
 
     /// NSUserActivity를 생성하여 앱의 SceneDelegate 또는 AppDelegate로 직접 전달합니다.
+    /// - Parameters:
+    ///   - url: 전달할 Universal Link URL
+    ///   - windowScene: 호출처의 windowScene. nil이면 foreground active scene을 탐색합니다.
+    /// - Returns: delegate에 전달 성공 여부
     @available(iOSApplicationExtension, unavailable)
-    static func openAsUniversalLink(_ url: URL) {
+    @discardableResult
+    static func openAsUniversalLink(_ url: URL, in windowScene: UIWindowScene? = nil) -> Bool {
         Logger.info("[Notifly] Opening as Universal Link via NSUserActivity: \(url)")
         let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
         activity.webpageURL = url
 
+        // 1) 명시적으로 전달받은 scene 사용
+        if let scene = windowScene, let sceneDelegate = scene.delegate {
+            Logger.info("[Notifly] Forwarding to SceneDelegate (explicit scene)")
+            sceneDelegate.scene?(scene, continue: activity)
+            return true
+        }
+
+        // 2) foreground active scene 탐색
         if let scene = UIApplication.shared.connectedScenes
             .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
            let sceneDelegate = scene.delegate
         {
-            Logger.info("[Notifly] Forwarding to SceneDelegate.scene(_:continue:)")
+            Logger.info("[Notifly] Forwarding to SceneDelegate (active scene)")
             sceneDelegate.scene?(scene, continue: activity)
-        } else if let appDelegate = UIApplication.shared.delegate {
-            Logger.info("[Notifly] Forwarding to AppDelegate.application(_:continue:)")
+            return true
+        }
+
+        // 3) AppDelegate fallback
+        if let appDelegate = UIApplication.shared.delegate {
+            Logger.info("[Notifly] Forwarding to AppDelegate")
             _ = appDelegate.application?(
                 UIApplication.shared,
                 continue: activity,
                 restorationHandler: { _ in }
             )
-        } else {
-            Logger.error("[Notifly] No delegate found to handle Universal Link")
+            return true
         }
+
+        Logger.error("[Notifly] No delegate found to handle Universal Link")
+        return false
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/NotiflyLinkHelper.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/NotiflyLinkHelper.swift
@@ -1,0 +1,93 @@
+import Foundation
+import SafariServices
+import UIKit
+
+/// 인앱 메시지 링크의 open mode 파싱, URL 정제, Universal Link 처리를 담당합니다.
+enum NotiflyLinkHelper {
+
+    // MARK: - Open Mode
+
+    private static let openModeParam = "nf_open_mode"
+
+    static func parseOpenMode(from url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == openModeParam })?.value
+    }
+
+    static func stripNotiflyParams(from url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return url }
+        components.queryItems = components.queryItems?.filter { $0.name != openModeParam }
+        if components.queryItems?.isEmpty == true { components.queryItems = nil }
+        return components.url ?? url
+    }
+
+    // MARK: - Universal Link Detection
+
+    private static var _cachedAssociatedDomains: [String]?
+    private static var _didLoadAssociatedDomains = false
+
+    static func getAssociatedDomains() -> [String] {
+        if _didLoadAssociatedDomains {
+            return _cachedAssociatedDomains ?? []
+        }
+        _didLoadAssociatedDomains = true
+
+        var rawDomains: [String] = []
+
+        if let execName = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String,
+           let execPath = Bundle.main.path(forResource: execName, ofType: nil),
+           let entitlements = try? EntitlementsReader(execPath).readEntitlements(),
+           let domains = entitlements["com.apple.developer.associated-domains"] as? [String]
+        {
+            rawDomains = domains
+        }
+
+        let hosts = rawDomains.compactMap { entry -> String? in
+            let cleaned = entry.components(separatedBy: "?").first ?? entry
+            guard cleaned.hasPrefix("applinks:") else { return nil }
+            return String(cleaned.dropFirst("applinks:".count)).lowercased()
+        }
+        _cachedAssociatedDomains = hosts
+        Logger.info("[Notifly] Associated domains: \(hosts)")
+        return hosts
+    }
+
+    static func isOwnUniversalLink(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              let host = url.host?.lowercased()
+        else { return false }
+        let domains = getAssociatedDomains()
+        let result = domains.contains(host)
+        Logger.info("[Notifly] isOwnUniversalLink: host=\(host), domains=\(domains), result=\(result)")
+        return result
+    }
+
+    // MARK: - Universal Link Forwarding
+
+    /// NSUserActivity를 생성하여 앱의 SceneDelegate 또는 AppDelegate로 직접 전달합니다.
+    @available(iOSApplicationExtension, unavailable)
+    static func openAsUniversalLink(_ url: URL) {
+        Logger.info("[Notifly] Opening as Universal Link via NSUserActivity: \(url)")
+        let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+        activity.webpageURL = url
+
+        if let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+           let sceneDelegate = scene.delegate
+        {
+            Logger.info("[Notifly] Forwarding to SceneDelegate.scene(_:continue:)")
+            sceneDelegate.scene?(scene, continue: activity)
+        } else if let appDelegate = UIApplication.shared.delegate {
+            Logger.info("[Notifly] Forwarding to AppDelegate.application(_:continue:)")
+            _ = appDelegate.application?(
+                UIApplication.shared,
+                continue: activity,
+                restorationHandler: { _ in }
+            )
+        } else {
+            Logger.error("[Notifly] No delegate found to handle Universal Link")
+        }
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/NotiflyLinkHelper.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/NotiflyLinkHelper.swift
@@ -24,33 +24,36 @@ enum NotiflyLinkHelper {
 
     // MARK: - Universal Link Detection
 
+    private static let domainQueue = DispatchQueue(label: "tech.notifly.link-helper.domains")
     private static var _cachedAssociatedDomains: [String]?
     private static var _didLoadAssociatedDomains = false
 
     static func getAssociatedDomains() -> [String] {
-        if _didLoadAssociatedDomains {
-            return _cachedAssociatedDomains ?? []
-        }
-        _didLoadAssociatedDomains = true
+        domainQueue.sync {
+            if _didLoadAssociatedDomains {
+                return _cachedAssociatedDomains ?? []
+            }
+            _didLoadAssociatedDomains = true
 
-        var rawDomains: [String] = []
+            var rawDomains: [String] = []
 
-        if let execName = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String,
-           let execPath = Bundle.main.path(forResource: execName, ofType: nil),
-           let entitlements = try? EntitlementsReader(execPath).readEntitlements(),
-           let domains = entitlements["com.apple.developer.associated-domains"] as? [String]
-        {
-            rawDomains = domains
-        }
+            if let execName = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String,
+               let execPath = Bundle.main.path(forResource: execName, ofType: nil),
+               let entitlements = try? EntitlementsReader(execPath).readEntitlements(),
+               let domains = entitlements["com.apple.developer.associated-domains"] as? [String]
+            {
+                rawDomains = domains
+            }
 
-        let hosts = rawDomains.compactMap { entry -> String? in
-            let cleaned = entry.components(separatedBy: "?").first ?? entry
-            guard cleaned.hasPrefix("applinks:") else { return nil }
-            return String(cleaned.dropFirst("applinks:".count)).lowercased()
+            let hosts = rawDomains.compactMap { entry -> String? in
+                let cleaned = entry.components(separatedBy: "?").first ?? entry
+                guard cleaned.hasPrefix("applinks:") else { return nil }
+                return String(cleaned.dropFirst("applinks:".count)).lowercased()
+            }
+            _cachedAssociatedDomains = hosts
+            Logger.info("[Notifly] Associated domains: \(hosts)")
+            return hosts
         }
-        _cachedAssociatedDomains = hosts
-        Logger.info("[Notifly] Associated domains: \(hosts)")
-        return hosts
     }
 
     static func isOwnUniversalLink(_ url: URL) -> Bool {
@@ -59,7 +62,12 @@ enum NotiflyLinkHelper {
               let host = url.host?.lowercased()
         else { return false }
         let domains = getAssociatedDomains()
-        let result = domains.contains(host)
+        let result = domains.contains { domain in
+            if domain.hasPrefix("*.") {
+                return host.hasSuffix(String(domain.dropFirst(1)))
+            }
+            return domain == host
+        }
         Logger.info("[Notifly] isOwnUniversalLink: host=\(host), domains=\(domains), result=\(result)")
         return result
     }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/NotiflyLinkHelperTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/NotiflyLinkHelperTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import notifly_ios_sdk
+
+class NotiflyLinkHelperTests: XCTestCase {
+
+    // MARK: - parseOpenMode
+
+    func testParseOpenMode_inAppBrowser() {
+        let url = URL(string: "https://example.com?nf_open_mode=in_app_browser")!
+        XCTAssertEqual(NotiflyLinkHelper.parseOpenMode(from: url), "in_app_browser")
+    }
+
+    func testParseOpenMode_noParam() {
+        let url = URL(string: "https://example.com")!
+        XCTAssertNil(NotiflyLinkHelper.parseOpenMode(from: url))
+    }
+
+    func testParseOpenMode_otherParams() {
+        let url = URL(string: "https://example.com?foo=bar&nf_open_mode=in_app_browser&baz=qux")!
+        XCTAssertEqual(NotiflyLinkHelper.parseOpenMode(from: url), "in_app_browser")
+    }
+
+    func testParseOpenMode_unknownValue() {
+        let url = URL(string: "https://example.com?nf_open_mode=unknown")!
+        XCTAssertEqual(NotiflyLinkHelper.parseOpenMode(from: url), "unknown")
+    }
+
+    // MARK: - stripNotiflyParams
+
+    func testStripNotiflyParams_removesOpenMode() {
+        let url = URL(string: "https://example.com?nf_open_mode=in_app_browser")!
+        let stripped = NotiflyLinkHelper.stripNotiflyParams(from: url)
+        XCTAssertEqual(stripped.absoluteString, "https://example.com")
+        XCTAssertNil(stripped.query)
+    }
+
+    func testStripNotiflyParams_preservesOtherParams() {
+        let url = URL(string: "https://example.com?foo=bar&nf_open_mode=in_app_browser&baz=qux")!
+        let stripped = NotiflyLinkHelper.stripNotiflyParams(from: url)
+        XCTAssertTrue(stripped.absoluteString.contains("foo=bar"))
+        XCTAssertTrue(stripped.absoluteString.contains("baz=qux"))
+        XCTAssertFalse(stripped.absoluteString.contains("nf_open_mode"))
+    }
+
+    func testStripNotiflyParams_noParams() {
+        let url = URL(string: "https://example.com")!
+        let stripped = NotiflyLinkHelper.stripNotiflyParams(from: url)
+        XCTAssertEqual(stripped.absoluteString, "https://example.com")
+    }
+
+    func testStripNotiflyParams_noOpenModeParam() {
+        let url = URL(string: "https://example.com?foo=bar")!
+        let stripped = NotiflyLinkHelper.stripNotiflyParams(from: url)
+        XCTAssertEqual(stripped.absoluteString, "https://example.com?foo=bar")
+    }
+
+    // MARK: - isOwnUniversalLink
+
+    func testIsOwnUniversalLink_httpScheme() {
+        // entitlements 읽기가 안 되는 테스트 환경에서는 항상 false
+        let url = URL(string: "https://example.com/path")!
+        let result = NotiflyLinkHelper.isOwnUniversalLink(url)
+        // 테스트 바이너리에는 associated domains가 없으므로 false
+        XCTAssertFalse(result)
+    }
+
+    func testIsOwnUniversalLink_customScheme() {
+        let url = URL(string: "myapp://deeplink")!
+        XCTAssertFalse(NotiflyLinkHelper.isOwnUniversalLink(url))
+    }
+
+    func testIsOwnUniversalLink_noScheme() {
+        let url = URL(string: "example.com")!
+        XCTAssertFalse(NotiflyLinkHelper.isOwnUniversalLink(url))
+    }
+
+    // MARK: - EntitlementsReader
+
+    func testEntitlementsReader_readFromCurrentBinary() {
+        // 현재 테스트 바이너리에서 entitlements 읽기 시도
+        guard let execName = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String,
+              let execPath = Bundle.main.path(forResource: execName, ofType: nil)
+        else {
+            // 테스트 환경에 따라 바이너리 경로가 없을 수 있음
+            return
+        }
+
+        // 크래시 없이 완료되면 성공 (entitlements가 없어도 throw만 하고 크래시는 안 함)
+        do {
+            let entitlements = try EntitlementsReader(execPath).readEntitlements()
+            // entitlements가 있으면 dictionary여야 함
+            XCTAssertTrue(type(of: entitlements) == [String: Any].self)
+        } catch {
+            // 테스트 바이너리에 코드 서명이 없을 수 있음 — 정상적인 실패
+            XCTAssertTrue(error is EntitlementsReader.Error)
+        }
+    }
+
+    func testEntitlementsReader_invalidPath() {
+        XCTAssertThrowsError(try EntitlementsReader("/nonexistent/path")) { error in
+            guard let readerError = error as? EntitlementsReader.Error else {
+                XCTFail("Expected EntitlementsReader.Error")
+                return
+            }
+            XCTAssertEqual(String(describing: readerError), String(describing: EntitlementsReader.Error.binaryOpeningError))
+        }
+    }
+
+    // MARK: - Wildcard Domain Matching
+
+    func testWildcardDomainMatching() {
+        // isOwnUniversalLink 내부 로직과 동일한 매칭 테스트
+        let domains = ["example.com", "*.wildcard.com"]
+
+        func matches(host: String) -> Bool {
+            domains.contains { domain in
+                if domain.hasPrefix("*.") {
+                    return host.hasSuffix(String(domain.dropFirst(1)))
+                }
+                return domain == host
+            }
+        }
+
+        XCTAssertTrue(matches(host: "example.com"))
+        XCTAssertFalse(matches(host: "sub.example.com"))
+        XCTAssertTrue(matches(host: "sub.wildcard.com"))
+        XCTAssertTrue(matches(host: "deep.sub.wildcard.com"))
+        XCTAssertFalse(matches(host: "wildcard.com"))
+        XCTAssertFalse(matches(host: "other.com"))
+    }
+}

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '2.3.1'
+  s.version          = '2.4.0'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 2.3.1
+  NOTIFLY iOS SDK : 2.4.0
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'

--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk_push_extension'
-  s.version          = '2.3.1'
+  s.version          = '2.4.0'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS Push Extension SDK : 2.3.1
+  NOTIFLY iOS Push Extension SDK : 2.4.0
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary
- 인앱 메시지 버튼 링크 URL에 `?nf_open_mode=in_app_browser` 파라미터 추가 시 외부 브라우저 대신 SFSafariViewController로 열리도록 지원
- 파라미터 없는 기존 캠페인은 동작 변경 없음 (하위 호환)
- 트래킹 이벤트에는 `nf_open_mode` 파라미터가 제거된 clean URL 사용

## 변경 파일
- `WebViewModalViewController.swift` — `main_button` 분기 + `parseOpenMode()`, `stripNotiflyParams()` 헬퍼 추가 + SFSafariViewController import

## Test plan
- [x] `?nf_open_mode=in_app_browser` URL → SFSafariViewController 열림 확인
- [x] 파라미터 없는 URL → 기존대로 외부 브라우저(Safari) 열림 확인
- [x] 트래킹 이벤트의 link 값에 `nf_open_mode` 파라미터 미포함 확인
- [x] SFSafariViewController dismiss 시 원래 앱 화면으로 정상 복귀 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인앱 메시지의 CTA 선택 시 nf_open_mode 및 URL 스킴을 기반으로 앱 내 브라우저 또는 기본 브라우저로 자동 열기
  * 앱 소유 유니버설 링크는 시스템 방식으로 전달하여 네이티브 처리 지원

* **개선사항**
  * 메시지 닫힘과 브라우저 전환이 안전한 순서로 처리되어 전환이 더 부드러움
  * 클릭 이벤트에 전송되는 링크가 동작 파라미터를 제거한 정제된 URL로 개선되어 추적 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->