### PR TITLE
feat: SSE 클라이언트 코어 구현

### DIFF
--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8088603A8294AD238004B695 /* SSEClientTests.swift */; };
 		2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */; };
 		2BA67CD02C353D6C00240C17 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */; };
+		4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */; };
 		672E7DF329EFA50400B3E9F2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 672E7DF229EFA50400B3E9F2 /* FirebaseMessaging */; };
 		673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */; };
 		673F0E8B29EBA7D200814217 /* notifly_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */; };
@@ -24,6 +25,7 @@
 		AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF8FB665159427B654E3954 /* SSEClient.swift */; };
 		B0521E422C1B572100D4E357 /* Timezone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0521E412C1B572100D4E357 /* Timezone.swift */; };
 		B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */; };
+		D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */; };
 		F2E6697B2ADE600000DF9CA0 /* NotiflyExtensionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */; };
 		F2E6697C2ADE600000DF9CA0 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */; };
 		F2E6698F2ADE602900DF9CA0 /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697F2ADE602900DF9CA0 /* NotificationsManager.swift */; };
@@ -75,8 +77,10 @@
 		673F0E8A29EBA7D200814217 /* notifly-ios-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "notifly-ios-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notifly_ios_sdkTests.swift; sourceTree = "<group>"; };
 		673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notifly+PublicAPI.swift"; sourceTree = "<group>"; };
+		7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientResponseValidationTests.swift; sourceTree = "<group>"; };
 		8088603A8294AD238004B695 /* SSEClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientTests.swift; sourceTree = "<group>"; };
 		8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEEvent.swift; sourceTree = "<group>"; };
+		99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientTestSupport.swift; sourceTree = "<group>"; };
 		AA00000000000002 /* NotiflyLinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelper.swift; sourceTree = "<group>"; };
 		AA00000000000004 /* ApplicationBinary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBinary.swift; sourceTree = "<group>"; };
 		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
@@ -136,6 +140,8 @@
 			children = (
 				2CC56C102B6001B31A226813 /* SSELineParserTests.swift */,
 				8088603A8294AD238004B695 /* SSEClientTests.swift */,
+				99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */,
+				7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */,
 			);
 			name = SSE;
 			path = SSE;
@@ -483,6 +489,8 @@
 				AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */,
 				10A6432EEA64DAA79DEE3CEE /* SSELineParserTests.swift in Sources */,
 				1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */,
+				4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */,
+				D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -7,15 +7,23 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		10A6432EEA64DAA79DEE3CEE /* SSELineParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC56C102B6001B31A226813 /* SSELineParserTests.swift */; };
+		1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8088603A8294AD238004B695 /* SSEClientTests.swift */; };
 		2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */; };
 		2BA67CD02C353D6C00240C17 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */; };
 		672E7DF329EFA50400B3E9F2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 672E7DF229EFA50400B3E9F2 /* FirebaseMessaging */; };
 		673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */; };
 		673F0E8B29EBA7D200814217 /* notifly_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */; };
 		673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */; };
-		AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000011 /* NotiflyLinkHelperTests.swift */; };
 		673F0EBB29EC610400814217 /* Notifly+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */; };
+		8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EB4E2A48E97C9719C16565 /* SSELineParser.swift */; };
+		AA00000000000001 /* NotiflyLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000002 /* NotiflyLinkHelper.swift */; };
+		AA00000000000003 /* ApplicationBinary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000004 /* ApplicationBinary.swift */; };
+		AA00000000000005 /* EntitlementsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000006 /* EntitlementsReader.swift */; };
+		AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000011 /* NotiflyLinkHelperTests.swift */; };
+		AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF8FB665159427B654E3954 /* SSEClient.swift */; };
 		B0521E422C1B572100D4E357 /* Timezone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0521E412C1B572100D4E357 /* Timezone.swift */; };
+		B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */; };
 		F2E6697B2ADE600000DF9CA0 /* NotiflyExtensionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */; };
 		F2E6697C2ADE600000DF9CA0 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */; };
 		F2E6698F2ADE602900DF9CA0 /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697F2ADE602900DF9CA0 /* NotificationsManager.swift */; };
@@ -29,9 +37,6 @@
 		F2E669982ADE602900DF9CA0 /* TrackingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6698C2ADE602900DF9CA0 /* TrackingManager.swift */; };
 		F2E669992ADE602900DF9CA0 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6698E2ADE602900DF9CA0 /* UserManager.swift */; };
 		F2E6699A2ADE60A600DF9CA0 /* AppHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669762ADE5FD000DF9CA0 /* AppHelper.swift */; };
-		AA00000000000001 /* NotiflyLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000002 /* NotiflyLinkHelper.swift */; };
-		AA00000000000003 /* ApplicationBinary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000004 /* ApplicationBinary.swift */; };
-		AA00000000000005 /* EntitlementsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000006 /* EntitlementsReader.swift */; };
 		F2E6699B2ADE60AA00DF9CA0 /* Notifly.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669772ADE5FD000DF9CA0 /* Notifly.swift */; };
 		F2E6699C2ADE60AD00DF9CA0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */; };
 		F2E6699D2ADE60AF00DF9CA0 /* NotiflyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */; };
@@ -62,12 +67,20 @@
 		2B91499B2BDA3C3A0066CDD0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncWorker.swift; sourceTree = "<group>"; };
 		2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
+		2CC56C102B6001B31A226813 /* SSELineParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParserTests.swift; sourceTree = "<group>"; };
+		4DF8FB665159427B654E3954 /* SSEClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClient.swift; sourceTree = "<group>"; };
+		58EB4E2A48E97C9719C16565 /* SSELineParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParser.swift; sourceTree = "<group>"; };
 		673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = notifly_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = notifly_ios_sdk.docc; sourceTree = "<group>"; };
 		673F0E8A29EBA7D200814217 /* notifly-ios-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "notifly-ios-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notifly_ios_sdkTests.swift; sourceTree = "<group>"; };
-		AA00000000000011 /* NotiflyLinkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelperTests.swift; sourceTree = "<group>"; };
 		673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notifly+PublicAPI.swift"; sourceTree = "<group>"; };
+		8088603A8294AD238004B695 /* SSEClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientTests.swift; sourceTree = "<group>"; };
+		8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEEvent.swift; sourceTree = "<group>"; };
+		AA00000000000002 /* NotiflyLinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelper.swift; sourceTree = "<group>"; };
+		AA00000000000004 /* ApplicationBinary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBinary.swift; sourceTree = "<group>"; };
+		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
+		AA00000000000011 /* NotiflyLinkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelperTests.swift; sourceTree = "<group>"; };
 		B0521E412C1B572100D4E357 /* Timezone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timezone.swift; sourceTree = "<group>"; };
 		F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyError.swift; sourceTree = "<group>"; };
@@ -78,9 +91,6 @@
 		F2E669732ADE5F7E00DF9CA0 /* UUID+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UUID+.swift"; sourceTree = "<group>"; };
 		F2E669742ADE5F7E00DF9CA0 /* TrackingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEvent.swift; sourceTree = "<group>"; };
 		F2E669762ADE5FD000DF9CA0 /* AppHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHelper.swift; sourceTree = "<group>"; };
-		AA00000000000002 /* NotiflyLinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelper.swift; sourceTree = "<group>"; };
-		AA00000000000004 /* ApplicationBinary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBinary.swift; sourceTree = "<group>"; };
-		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
 		F2E669772ADE5FD000DF9CA0 /* Notifly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifly.swift; sourceTree = "<group>"; };
 		F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotiflyExtensionAPI.swift; sourceTree = "<group>"; };
 		F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationServiceExtension.swift; sourceTree = "<group>"; };
@@ -121,6 +131,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		074A991EAD22EC70CA4CFBC7 /* SSE */ = {
+			isa = PBXGroup;
+			children = (
+				2CC56C102B6001B31A226813 /* SSELineParserTests.swift */,
+				8088603A8294AD238004B695 /* SSEClientTests.swift */,
+			);
+			name = SSE;
+			path = SSE;
+			sourceTree = "<group>";
+		};
+		3273667AAB6C57C5AD35F0FB /* SSE */ = {
+			isa = PBXGroup;
+			children = (
+				8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */,
+				58EB4E2A48E97C9719C16565 /* SSELineParser.swift */,
+				4DF8FB665159427B654E3954 /* SSEClient.swift */,
+			);
+			name = SSE;
+			path = SSE;
+			sourceTree = "<group>";
+		};
 		673F0E7629EBA7D200814217 = {
 			isa = PBXGroup;
 			children = (
@@ -155,6 +186,7 @@
 			children = (
 				673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */,
 				AA00000000000011 /* NotiflyLinkHelperTests.swift */,
+				074A991EAD22EC70CA4CFBC7 /* SSE */,
 			);
 			path = "notifly-ios-sdkTests";
 			sourceTree = "<group>";
@@ -228,6 +260,7 @@
 				F2E6697E2ADE602900DF9CA0 /* Notifications */,
 				F2E6698B2ADE602900DF9CA0 /* Tracking */,
 				F2E6698D2ADE602900DF9CA0 /* User */,
+				3273667AAB6C57C5AD35F0FB /* SSE */,
 			);
 			path = Infrastructures;
 			sourceTree = "<group>";
@@ -436,6 +469,9 @@
 				F2E669902ADE602900DF9CA0 /* Auth.swift in Sources */,
 				F2E669912ADE602900DF9CA0 /* InAppMessage+Constant.swift in Sources */,
 				F2E6699C2ADE60AD00DF9CA0 /* Constants.swift in Sources */,
+				B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */,
+				8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */,
+				AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -445,6 +481,8 @@
 			files = (
 				673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */,
 				AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */,
+				10A6432EEA64DAA79DEE3CEE /* SSELineParserTests.swift in Sources */,
+				1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
@@ -253,8 +253,13 @@ final class SSEClient: @unchecked Sendable {
         let request = try makeRequest(token: token)
 
         let (http, lines) = try await streamLineProvider(request)
-        guard (200..<300).contains(http.statusCode) else {
+        // 200 외 status (204, 304 등) 는 빈 body 로 즉시 종료 → 재연결 thrashing 유발하므로 reject.
+        guard http.statusCode == 200 else {
             throw ConnectionError.httpStatus(http.statusCode)
+        }
+        let contentType = (http.value(forHTTPHeaderField: "Content-Type") ?? "").lowercased()
+        guard contentType.hasPrefix("text/event-stream") else {
+            throw ConnectionError.invalidResponse
         }
 
         transition(to: .open)

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
@@ -1,0 +1,397 @@
+//
+//  SSEClient.swift
+//  notifly-ios-sdk
+//
+//  서버→SDK 실시간 채널의 트랜스포트 계층.
+//  URLSession.bytes(for:) + AsyncSequence 기반으로 SSE 스트림을 수신하고
+//  지수 백오프 재연결 / heartbeat 타임아웃 / Last-Event-ID 관리를 수행한다.
+//
+
+import Foundation
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEClient: @unchecked Sendable {
+
+    // MARK: - Public types
+
+    enum State: Equatable {
+        case idle
+        case connecting
+        case open
+        case reconnecting(attempt: Int)
+        case stopped
+    }
+
+    enum ConnectionError: Error, Equatable {
+        case invalidURL
+        case invalidResponse
+        case httpStatus(Int)
+        case heartbeatTimeout
+    }
+
+    /// HTTP 응답 헤더 + line 시퀀스를 반환. 테스트는 결정적 라인 입력을 주입할 수 있다.
+    typealias StreamLineProvider = (URLRequest) async throws -> (HTTPURLResponse, AsyncThrowingStream<String, Error>)
+
+    // MARK: - Static defaults
+
+    static let defaultBackoffSchedule: [TimeInterval] = [1, 2, 4, 8, 30]
+    static let defaultHeartbeatTimeout: TimeInterval = 60
+    /// .open 이 이 시간 이상 유지된 뒤 끊기면 정상 운영 상태로 간주, 백오프 attempt 카운터를 리셋한다.
+    static let openStableThreshold: TimeInterval = 30
+
+    static func makeDefaultSession() -> URLSession {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 5
+        // 서버 Connection TTL 30분(±10%) 보다 긴 35분.
+        config.timeoutIntervalForResource = 35 * 60
+        config.waitsForConnectivity = false
+        return URLSession(configuration: config)
+    }
+
+    // MARK: - Configuration (immutable)
+
+    private let projectId: String
+    private let notiflyUserId: String
+    private let deviceId: String?
+    private let tokenProvider: () async throws -> String
+    /// nil 이면 connect 시 makeRequest 가 invalidURL throw 하여 백오프 진입.
+    /// SDK 는 host app 을 죽이지 않으므로 init 자체는 항상 성공시킨다.
+    private let baseURL: URL?
+    private let backoffSchedule: [TimeInterval]
+    private let heartbeatTimeout: TimeInterval
+    private let streamLineProvider: StreamLineProvider
+    private let jitterProvider: () -> Double
+    private let nowProvider: () -> Date
+
+    // MARK: - Mutable state (stateAccessQueue 로 보호)
+
+    private let stateAccessQueue = DispatchQueue(label: "com.notifly.sse.stateAccessQueue")
+    private var _state: State = .idle
+    private var _lastEventId: String?
+    private var _connectionTask: Task<Void, Never>?
+    private var _lastDataAt: Date
+    private var _lastOpenAt: Date?
+
+    // MARK: - Callbacks
+    //
+    // 콜백 호출은 main queue 로 dispatch 된다. 콜백 클로저 내부에서 동일 SSEClient 의
+    // setter 를 호출하면 stateAccessQueue self-recursive sync 로 deadlock 가능하니 호출자가 회피.
+
+    var onMessage: ((_ type: String, _ data: String) -> Void)? {
+        get { stateAccessQueue.sync { _onMessage } }
+        set { stateAccessQueue.sync { _onMessage = newValue } }
+    }
+    var onState: ((State) -> Void)? {
+        get { stateAccessQueue.sync { _onState } }
+        set { stateAccessQueue.sync { _onState = newValue } }
+    }
+    private var _onMessage: ((_ type: String, _ data: String) -> Void)?
+    private var _onState: ((State) -> Void)?
+
+    // MARK: - Init
+
+    init(
+        projectId: String,
+        notiflyUserId: String,
+        deviceId: String?,
+        tokenProvider: @escaping () async throws -> String,
+        session: URLSession = SSEClient.makeDefaultSession(),
+        baseURLString: String = NotiflyConstant.EndPoint.streamEndPoint,
+        backoffSchedule: [TimeInterval] = SSEClient.defaultBackoffSchedule,
+        heartbeatTimeout: TimeInterval = SSEClient.defaultHeartbeatTimeout,
+        streamLineProvider: StreamLineProvider? = nil,
+        jitterProvider: @escaping () -> Double = { Double.random(in: 0.8...1.2) },
+        nowProvider: @escaping () -> Date = { Date() }
+    ) {
+        self.projectId = projectId
+        self.notiflyUserId = notiflyUserId
+        self.deviceId = deviceId
+        self.tokenProvider = tokenProvider
+        // 잘못된 baseURLString → 컴파일타임 상수 fallback. 모두 실패해도 init 은 성공시키고
+        // connect 시점에 invalidURL throw 하도록 nil 로 둔다 (host app crash 방지).
+        let resolvedBaseURL = URL(string: baseURLString) ?? URL(string: NotiflyConstant.EndPoint.streamEndPoint)
+        if resolvedBaseURL == nil {
+            Logger.error("SSEClient: failed to resolve baseURL — connect will fail with invalidURL")
+        }
+        self.baseURL = resolvedBaseURL
+        self.backoffSchedule = backoffSchedule.isEmpty ? SSEClient.defaultBackoffSchedule : backoffSchedule
+        self.heartbeatTimeout = heartbeatTimeout
+        self.streamLineProvider = streamLineProvider ?? SSEClient.makeURLSessionStreamProvider(session: session)
+        self.jitterProvider = jitterProvider
+        self.nowProvider = nowProvider
+        self._lastDataAt = nowProvider()
+    }
+
+    private static func makeURLSessionStreamProvider(session: URLSession) -> StreamLineProvider {
+        return { request in
+            let (bytes, response) = try await session.bytes(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw ConnectionError.invalidResponse
+            }
+            let stream = AsyncThrowingStream<String, Error> { continuation in
+                let task = Task {
+                    do {
+                        for try await line in bytes.lines {
+                            continuation.yield(line)
+                        }
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+            return (http, stream)
+        }
+    }
+
+    deinit {
+        // Task.cancel() 은 thread-safe 라 stateAccessQueue 동기화 없이 호출.
+        // (deinit 안에서 자기 큐로 sync 들어가면 deadlock 가능.)
+        _connectionTask?.cancel()
+    }
+
+    // MARK: - Public API
+
+    /// 멱등. 이미 .connecting / .open / .reconnecting 이면 무시한다.
+    /// 강제 reconnect 는 disconnect() + connect() 조합으로 가능.
+    func connect() {
+        // Task 생성과 _connectionTask 할당이 한 sync 블록에 묶여야
+        // disconnect() 와 race 시 새 task 가 누락되지 않는다.
+        var didStart = false
+        stateAccessQueue.sync {
+            switch _state {
+            case .connecting, .open, .reconnecting:
+                return
+            default:
+                break
+            }
+            _connectionTask?.cancel()
+            _state = .connecting
+            let task = Task { [weak self] in
+                guard let self = self else { return }
+                await self.runConnectionLoop()
+            }
+            _connectionTask = task
+            didStart = true
+        }
+        if didStart {
+            emitState(.connecting)
+        }
+    }
+
+    /// .stopped 로 전이하고 진행 중인 연결을 취소. 이후 connect() 로 재시작 가능.
+    func disconnect() {
+        var alreadyStopped = false
+        var connTask: Task<Void, Never>?
+        stateAccessQueue.sync {
+            alreadyStopped = (_state == .stopped)
+            connTask = _connectionTask
+            _connectionTask = nil
+            _state = .stopped
+        }
+
+        connTask?.cancel()
+        if !alreadyStopped {
+            emitState(.stopped)
+        }
+    }
+
+    var state: State {
+        stateAccessQueue.sync { _state }
+    }
+
+    var lastEventId: String? {
+        stateAccessQueue.sync { _lastEventId }
+    }
+
+    // MARK: - 연결 루프
+
+    private func runConnectionLoop() async {
+        var attempt = 0
+
+        while !Task.isCancelled, !isStopped() {
+            do {
+                try await runOneConnection(attempt: attempt)
+            } catch is CancellationError {
+                break
+            } catch {
+                Logger.info("SSE connection error: \(error)")
+            }
+
+            if isStopped() || Task.isCancelled { break }
+
+            // .open 으로 충분히 오래 유지된 뒤 끊긴 경우만 정상 운영으로 간주, attempt 리셋.
+            // connecting 단계만 길어진 케이스는 백오프 누적 유지.
+            let openedAt: Date? = stateAccessQueue.sync { _lastOpenAt }
+            if let openedAt = openedAt,
+               nowProvider().timeIntervalSince(openedAt) >= SSEClient.openStableThreshold {
+                attempt = 0
+            }
+
+            attempt += 1
+            transition(to: .reconnecting(attempt: attempt))
+            let delay = backoffDelay(attempt: attempt)
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds(from: delay))
+            } catch {
+                break
+            }
+        }
+    }
+
+    private func runOneConnection(attempt: Int) async throws {
+        if attempt > 0 {
+            transition(to: .connecting)
+        }
+
+        // long-idle 후 connect() 호출 시 watchdog 가 첫 라인 받기 전에 잘못 timeout 판정하지 않도록
+        // tokenProvider 직전에 lastDataAt 을 다시 찍는다.
+        setLastDataAt(nowProvider())
+
+        let token = try await tokenProvider()
+        let request = try makeRequest(token: token)
+
+        let (http, lines) = try await streamLineProvider(request)
+        guard (200..<300).contains(http.statusCode) else {
+            throw ConnectionError.httpStatus(http.statusCode)
+        }
+
+        transition(to: .open)
+        setLastDataAt(nowProvider())
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { [weak self] in
+                guard let self = self else { return }
+                try await self.consumeStream(lines: lines)
+            }
+            group.addTask { [weak self] in
+                guard let self = self else { return }
+                try await self.runHeartbeatWatchdog()
+            }
+            // 첫 child 완료(정상 종료 또는 throw)까지 대기 → 나머지 취소.
+            _ = try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    private func consumeStream(lines: AsyncThrowingStream<String, Error>) async throws {
+        let parser = SSELineParser()
+        for try await line in lines {
+            try Task.checkCancellation()
+            setLastDataAt(nowProvider())
+            if let event = parser.feed(line) {
+                if let id = event.id {
+                    setLastEventId(id)
+                }
+                emitMessage(type: event.type, data: event.data)
+            }
+        }
+    }
+
+    private func runHeartbeatWatchdog() async throws {
+        // timeout 의 1/4 분해능, 상한 5s — 60s timeout 이라도 worst-case 65s 안에 reconnect.
+        let checkInterval = max(min(heartbeatTimeout / 4, 5), 0.05)
+        while !Task.isCancelled {
+            try await Task.sleep(nanoseconds: nanoseconds(from: checkInterval))
+            let elapsed = nowProvider().timeIntervalSince(getLastDataAt())
+            if elapsed > heartbeatTimeout {
+                Logger.info("SSE heartbeat timeout: \(Int(elapsed))s")
+                throw ConnectionError.heartbeatTimeout
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func isStopped() -> Bool {
+        stateAccessQueue.sync { _state == .stopped }
+    }
+
+    private func transition(to new: State) {
+        let changed: Bool = stateAccessQueue.sync {
+            // .stopped 는 흡수 상태.
+            if _state == .stopped {
+                return false
+            }
+            let did = _state != new
+            _state = new
+            // .open 진입 시점만 기록. 그 외 상태에서는 stale 판정 방지를 위해 nil.
+            if case .open = new {
+                _lastOpenAt = nowProvider()
+            } else {
+                _lastOpenAt = nil
+            }
+            return did
+        }
+        if changed {
+            emitState(new)
+        }
+    }
+
+    private func emitState(_ s: State) {
+        let cb: ((State) -> Void)? = stateAccessQueue.sync { _onState }
+        DispatchQueue.main.async { cb?(s) }
+    }
+
+    private func emitMessage(type: String, data: String) {
+        let cb: ((String, String) -> Void)? = stateAccessQueue.sync { _onMessage }
+        DispatchQueue.main.async { cb?(type, data) }
+    }
+
+    private func setLastDataAt(_ d: Date) {
+        stateAccessQueue.sync { _lastDataAt = d }
+    }
+
+    private func getLastDataAt() -> Date {
+        stateAccessQueue.sync { _lastDataAt }
+    }
+
+    private func setLastEventId(_ id: String) {
+        stateAccessQueue.sync { _lastEventId = id }
+    }
+
+    private func backoffDelay(attempt: Int) -> TimeInterval {
+        let idx = min(max(attempt - 1, 0), backoffSchedule.count - 1)
+        let base = backoffSchedule[idx]
+        return base * jitterProvider()
+    }
+
+    private func nanoseconds(from seconds: TimeInterval) -> UInt64 {
+        return UInt64(max(seconds, 0) * 1_000_000_000)
+    }
+
+    private func makeRequest(token: String) throws -> URLRequest {
+        guard let baseURL = baseURL else {
+            throw ConnectionError.invalidURL
+        }
+        var components = URLComponents()
+        components.scheme = baseURL.scheme
+        components.host = baseURL.host
+        components.port = baseURL.port
+        // path component reserved/non-ASCII 대비 percent-encode.
+        let encodedProjectId = projectId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? projectId
+        let encodedUserId = notiflyUserId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? notiflyUserId
+        // baseURL.path 의 trailing slash 로 인한 // double slash 방지.
+        let normalizedBasePath = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let prefix = normalizedBasePath.isEmpty ? "" : "/\(normalizedBasePath)"
+        components.path = "\(prefix)/\(encodedProjectId)/\(encodedUserId)"
+        if let device = deviceId, !device.isEmpty {
+            components.queryItems = [URLQueryItem(name: "deviceId", value: device)]
+        }
+        guard let url = components.url else {
+            throw ConnectionError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+        let last: String? = stateAccessQueue.sync { _lastEventId }
+        if let last = last, !last.isEmpty {
+            request.setValue(last, forHTTPHeaderField: "Last-Event-ID")
+        }
+        return request
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEEvent.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEEvent.swift
@@ -1,0 +1,14 @@
+//
+//  SSEEvent.swift
+//  notifly-ios-sdk
+//
+//  Server-Sent Events 스펙(WHATWG)에 따른 단일 이벤트 표현.
+//
+
+import Foundation
+
+struct SSEEvent: Equatable {
+    let id: String?
+    let type: String
+    let data: String
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSELineParser.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSELineParser.swift
@@ -1,0 +1,85 @@
+//
+//  SSELineParser.swift
+//  notifly-ios-sdk
+//
+//  WHATWG "Server-sent events" 스펙에 따라 라인 입력을 누적해 SSEEvent 로 dispatch.
+//
+
+import Foundation
+
+final class SSELineParser {
+    private var eventType: String?
+    private var dataLines: [String] = []
+    private var isFirstLine: Bool = true
+
+    private(set) var lastEventId: String?
+
+    func feed(_ rawLine: String) -> SSEEvent? {
+        let line = stripLineEnding(rawLine)
+
+        if line.isEmpty {
+            return dispatch()
+        }
+        if line.hasPrefix(":") {
+            return nil
+        }
+
+        let (field, value) = Self.splitFieldValue(line)
+        switch field {
+        case "id":
+            // 스펙: U+0000 포함 id 는 무시.
+            if !value.contains("\0") {
+                lastEventId = value
+            }
+        case "event":
+            eventType = value
+        case "data":
+            dataLines.append(value)
+        case "retry":
+            break
+        default:
+            break
+        }
+        return nil
+    }
+
+    private func dispatch() -> SSEEvent? {
+        defer {
+            eventType = nil
+            dataLines.removeAll()
+        }
+        guard !dataLines.isEmpty else { return nil }
+        return SSEEvent(
+            id: lastEventId,
+            type: eventType ?? "message",
+            data: dataLines.joined(separator: "\n")
+        )
+    }
+
+    private func stripLineEnding(_ s: String) -> String {
+        var result = s
+        if result.hasSuffix("\r") {
+            result.removeLast()
+        }
+        // 스펙: BOM 은 스트림 첫 라인에만 제거. 이후 라인의 U+FEFF 는 데이터로 보존.
+        if isFirstLine {
+            if result.first == "\u{FEFF}" {
+                result.removeFirst()
+            }
+            isFirstLine = false
+        }
+        return result
+    }
+
+    private static func splitFieldValue(_ line: String) -> (String, String) {
+        guard let colonIdx = line.firstIndex(of: ":") else {
+            return (line, "")
+        }
+        let field = String(line[..<colonIdx])
+        var valueStart = line.index(after: colonIdx)
+        if valueStart < line.endIndex, line[valueStart] == " " {
+            valueStart = line.index(after: valueStart)
+        }
+        return (field, String(line[valueStart...]))
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -15,6 +15,7 @@ enum NotiflyConstant {
             "https://e.notifly.tech/records"
         static let syncStateEndPoint = "https://api.notifly.tech/user-state"
         static let authorizationEndPoint = "https://api.notifly.tech/authorize"
+        static let streamEndPoint = "https://api.notifly.tech/streams"
     }
 }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientResponseValidationTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientResponseValidationTests.swift
@@ -20,7 +20,7 @@ final class SSEClientResponseValidationTests: XCTestCase {
         client.connect()
 
         waitForCondition(description: "204 → backoff → second connect") {
-            pb.capturedRequests.count >= 2
+            pb.capturedRequestCount >= 2
         }
 
         XCTAssertTrue(
@@ -45,7 +45,7 @@ final class SSEClientResponseValidationTests: XCTestCase {
         client.connect()
 
         waitForCondition(description: "wrong content-type → backoff → second connect") {
-            pb.capturedRequests.count >= 2
+            pb.capturedRequestCount >= 2
         }
 
         XCTAssertTrue(

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientResponseValidationTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientResponseValidationTests.swift
@@ -1,0 +1,74 @@
+//
+//  SSEClientResponseValidationTests.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEClientResponseValidationTests: XCTestCase {
+
+    func test_204NoContent_isRejectedAndBacksOff() {
+        let pb = ProviderBuilder()
+        pb.enqueueNoContent(204)
+        pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "204 → backoff → second connect") {
+            pb.capturedRequests.count >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            },
+            "Expected .reconnecting after 204 in \(recorder.snapshot)"
+        )
+
+        client.disconnect()
+    }
+
+    func test_wrongContentType_isRejectedAndBacksOff() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpenWithContentType("application/json")
+        pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "wrong content-type → backoff → second connect") {
+            pb.capturedRequests.count >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            }
+        )
+
+        client.disconnect()
+    }
+
+    func test_eventStreamWithCharsetParam_isAccepted() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpenWithContentType("text/event-stream; charset=utf-8")
+
+        let opened = expectation(description: "opened")
+        let client = makeSSEClient(provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+        client.disconnect()
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
@@ -1,0 +1,189 @@
+//
+//  SSEClientTestSupport.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class TestStream: @unchecked Sendable {
+    let continuation: AsyncThrowingStream<String, Error>.Continuation
+    let stream: AsyncThrowingStream<String, Error>
+
+    init() {
+        var contRef: AsyncThrowingStream<String, Error>.Continuation!
+        self.stream = AsyncThrowingStream<String, Error> { c in contRef = c }
+        self.continuation = contRef
+    }
+
+    func write(_ line: String) {
+        continuation.yield(line)
+    }
+
+    func writeBlock(_ block: String) {
+        for line in block.components(separatedBy: "\n") {
+            continuation.yield(line)
+        }
+    }
+
+    func finish() {
+        continuation.finish()
+    }
+
+    func fail(_ error: Error) {
+        continuation.finish(throwing: error)
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+struct ProviderScenario {
+    var statusCode: Int = 200
+    var contentType: String = "text/event-stream"
+    var stream: TestStream?
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class ProviderBuilder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var scenarios: [ProviderScenario] = []
+    private(set) var capturedRequests: [URLRequest] = []
+    var onRequest: ((URLRequest) -> Void)?
+
+    func enqueue(_ scenario: ProviderScenario) {
+        lock.lock(); defer { lock.unlock() }
+        scenarios.append(scenario)
+    }
+
+    @discardableResult
+    func enqueueOpen(stream: TestStream = TestStream()) -> TestStream {
+        enqueue(ProviderScenario(statusCode: 200, stream: stream))
+        return stream
+    }
+
+    @discardableResult
+    func enqueueOpenWithContentType(_ contentType: String, stream: TestStream = TestStream()) -> TestStream {
+        enqueue(ProviderScenario(statusCode: 200, contentType: contentType, stream: stream))
+        return stream
+    }
+
+    func enqueueHTTPError(_ code: Int) {
+        enqueue(ProviderScenario(statusCode: code, stream: nil))
+    }
+
+    func enqueueNoContent(_ code: Int = 204) {
+        enqueue(ProviderScenario(statusCode: code, stream: nil))
+    }
+
+    func makeProvider() -> SSEClient.StreamLineProvider {
+        return { [weak self] request in
+            guard let self = self else { throw SSEClient.ConnectionError.invalidResponse }
+            self.lock.lock()
+            self.capturedRequests.append(request)
+            let cb = self.onRequest
+            let scenario = self.scenarios.isEmpty
+                ? ProviderScenario(statusCode: 500, stream: nil)
+                : self.scenarios.removeFirst()
+            self.lock.unlock()
+            cb?(request)
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: scenario.statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": scenario.contentType]
+            )!
+            let stream = scenario.stream?.stream ?? AsyncThrowingStream<String, Error> { c in
+                c.finish()
+            }
+            return (response, stream)
+        }
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class StateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [SSEClient.State] = []
+
+    func append(_ s: SSEClient.State) {
+        lock.lock(); defer { lock.unlock() }
+        states.append(s)
+    }
+
+    var snapshot: [SSEClient.State] {
+        lock.lock(); defer { lock.unlock() }
+        return states
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+extension XCTestCase {
+
+    func makeSSEClient(
+        deviceId: String? = "device-1",
+        backoff: [TimeInterval] = [0.05],
+        heartbeatTimeout: TimeInterval = SSEClient.defaultHeartbeatTimeout,
+        token: @escaping () async throws -> String = { "test-token" },
+        provider: @escaping SSEClient.StreamLineProvider
+    ) -> SSEClient {
+        return SSEClient(
+            projectId: "00000000000000000000000000000abc",
+            notiflyUserId: "user-42",
+            deviceId: deviceId,
+            tokenProvider: token,
+            baseURLString: "https://test.local/streams",
+            backoffSchedule: backoff,
+            heartbeatTimeout: heartbeatTimeout,
+            streamLineProvider: provider,
+            jitterProvider: { 1.0 }
+        )
+    }
+
+    func waitForCondition(
+        timeout: TimeInterval = 3,
+        description: String = "condition",
+        _ check: @escaping () -> Bool
+    ) {
+        let exp = expectation(description: description)
+        let queue = DispatchQueue.global()
+        var fulfilled = false
+        let lock = NSLock()
+        let deadline = Date().addingTimeInterval(timeout)
+        func tick() {
+            queue.asyncAfter(deadline: .now() + 0.02) {
+                lock.lock()
+                if fulfilled {
+                    lock.unlock()
+                    return
+                }
+                lock.unlock()
+                if check() {
+                    lock.lock()
+                    if !fulfilled {
+                        fulfilled = true
+                        lock.unlock()
+                        exp.fulfill()
+                    } else {
+                        lock.unlock()
+                    }
+                    return
+                }
+                if Date() < deadline {
+                    tick()
+                } else {
+                    lock.lock()
+                    if !fulfilled {
+                        fulfilled = true
+                        lock.unlock()
+                        exp.fulfill()
+                    } else {
+                        lock.unlock()
+                    }
+                }
+            }
+        }
+        tick()
+        wait(for: [exp], timeout: timeout + 1)
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
@@ -47,8 +47,18 @@ struct ProviderScenario {
 final class ProviderBuilder: @unchecked Sendable {
     private let lock = NSLock()
     private var scenarios: [ProviderScenario] = []
-    private(set) var capturedRequests: [URLRequest] = []
+    private var _capturedRequests: [URLRequest] = []
     var onRequest: ((URLRequest) -> Void)?
+
+    var capturedRequestCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _capturedRequests.count
+    }
+
+    var capturedRequestsSnapshot: [URLRequest] {
+        lock.lock(); defer { lock.unlock() }
+        return _capturedRequests
+    }
 
     func enqueue(_ scenario: ProviderScenario) {
         lock.lock(); defer { lock.unlock() }
@@ -79,7 +89,7 @@ final class ProviderBuilder: @unchecked Sendable {
         return { [weak self] request in
             guard let self = self else { throw SSEClient.ConnectionError.invalidResponse }
             self.lock.lock()
-            self.capturedRequests.append(request)
+            self._capturedRequests.append(request)
             let cb = self.onRequest
             let scenario = self.scenarios.isEmpty
                 ? ProviderScenario(statusCode: 500, stream: nil)
@@ -143,12 +153,15 @@ extension XCTestCase {
     func waitForCondition(
         timeout: TimeInterval = 3,
         description: String = "condition",
+        file: StaticString = #file,
+        line: UInt = #line,
         _ check: @escaping () -> Bool
     ) {
         let exp = expectation(description: description)
         let queue = DispatchQueue.global()
-        var fulfilled = false
         let lock = NSLock()
+        var fulfilled = false
+        var timedOut = false
         let deadline = Date().addingTimeInterval(timeout)
         func tick() {
             queue.asyncAfter(deadline: .now() + 0.02) {
@@ -175,6 +188,7 @@ extension XCTestCase {
                     lock.lock()
                     if !fulfilled {
                         fulfilled = true
+                        timedOut = true
                         lock.unlock()
                         exp.fulfill()
                     } else {
@@ -185,5 +199,11 @@ extension XCTestCase {
         }
         tick()
         wait(for: [exp], timeout: timeout + 1)
+        lock.lock()
+        let didTimeOut = timedOut
+        lock.unlock()
+        if didTimeOut {
+            XCTFail("waitForCondition timed out: \(description)", file: file, line: line)
+        }
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
@@ -50,6 +50,7 @@ final class SSEClientTests: XCTestCase {
     private final class ProviderBuilder: @unchecked Sendable {
         struct Scenario {
             var statusCode: Int = 200
+            var contentType: String = "text/event-stream"
             var stream: TestStream?
         }
 
@@ -68,7 +69,17 @@ final class SSEClientTests: XCTestCase {
             return stream
         }
 
+        func enqueueOpenWithContentType(_ contentType: String, stream: TestStream = TestStream()) -> TestStream {
+            enqueue(Scenario(statusCode: 200, contentType: contentType, stream: stream))
+            return stream
+        }
+
         func enqueueHTTPError(_ code: Int) {
+            enqueue(Scenario(statusCode: code, stream: nil))
+        }
+
+        /// non-200 success (204 등). body 비어있는 stream 으로 즉시 finish.
+        func enqueueNoContent(_ code: Int = 204) {
             enqueue(Scenario(statusCode: code, stream: nil))
         }
 
@@ -88,7 +99,7 @@ final class SSEClientTests: XCTestCase {
                     url: request.url!,
                     statusCode: scenario.statusCode,
                     httpVersion: "HTTP/1.1",
-                    headerFields: ["Content-Type": "text/event-stream"]
+                    headerFields: ["Content-Type": scenario.contentType]
                 )!
                 let stream = scenario.stream?.stream ?? AsyncThrowingStream<String, Error> { c in
                     c.finish()
@@ -317,6 +328,69 @@ final class SSEClientTests: XCTestCase {
             "Expected .reconnecting in \(recorder.snapshot)"
         )
 
+        client.disconnect()
+    }
+
+    func test_204NoContent_isRejectedAndBacksOff() {
+        let pb = ProviderBuilder()
+        pb.enqueueNoContent(204)
+        _ = pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "204 → backoff → second connect") {
+            pb.capturedRequests.count >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            },
+            "Expected .reconnecting after 204 in \(recorder.snapshot)"
+        )
+
+        client.disconnect()
+    }
+
+    func test_wrongContentType_isRejectedAndBacksOff() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpenWithContentType("application/json")
+        _ = pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "wrong content-type → backoff → second connect") {
+            pb.capturedRequests.count >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            }
+        )
+
+        client.disconnect()
+    }
+
+    func test_eventStreamWithCharsetParam_isAccepted() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpenWithContentType("text/event-stream; charset=utf-8")
+
+        let opened = expectation(description: "opened")
+        let client = makeClient(provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
         client.disconnect()
     }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
@@ -78,7 +78,7 @@ final class SSEClientTests: XCTestCase {
         client.connect()
         wait(for: [opened], timeout: 3)
 
-        let captured = pb.capturedRequests.first
+        let captured = pb.capturedRequestsSnapshot.first
         XCTAssertNotNil(captured)
         XCTAssertEqual(captured?.value(forHTTPHeaderField: "Authorization"), "Bearer my-token")
         XCTAssertEqual(captured?.value(forHTTPHeaderField: "Accept"), "text/event-stream")
@@ -101,7 +101,7 @@ final class SSEClientTests: XCTestCase {
         client.connect()
         wait(for: [opened], timeout: 3)
 
-        XCTAssertNil(pb.capturedRequests.first?.url?.query)
+        XCTAssertNil(pb.capturedRequestsSnapshot.first?.url?.query)
         client.disconnect()
     }
 
@@ -126,9 +126,9 @@ final class SSEClientTests: XCTestCase {
         }
 
         wait(for: [firstReceived], timeout: 3)
-        waitForCondition(description: "second request") { pb.capturedRequests.count >= 2 }
+        waitForCondition(description: "second request") { pb.capturedRequestCount >= 2 }
 
-        let secondRequest = pb.capturedRequests[1]
+        let secondRequest = pb.capturedRequestsSnapshot[1]
         XCTAssertEqual(secondRequest.value(forHTTPHeaderField: "Last-Event-ID"), "42")
         XCTAssertEqual(client.lastEventId, "42")
 
@@ -148,7 +148,7 @@ final class SSEClientTests: XCTestCase {
         client.connect()
 
         waitForCondition(description: "second request after 503") {
-            pb.capturedRequests.count >= 2
+            pb.capturedRequestCount >= 2
         }
 
         XCTAssertTrue(
@@ -184,7 +184,7 @@ final class SSEClientTests: XCTestCase {
             assertion.fulfill()
         }
         wait(for: [assertion], timeout: 2)
-        XCTAssertEqual(pb.capturedRequests.count, 1)
+        XCTAssertEqual(pb.capturedRequestCount, 1)
 
         client.disconnect()
     }
@@ -235,7 +235,7 @@ final class SSEClientTests: XCTestCase {
         client.connect()
         wait(for: [secondOpen], timeout: 3)
 
-        XCTAssertEqual(pb.capturedRequests.count, 2)
+        XCTAssertEqual(pb.capturedRequestCount, 2)
         client.disconnect()
     }
 
@@ -256,7 +256,7 @@ final class SSEClientTests: XCTestCase {
         client.connect()
 
         waitForCondition(timeout: 5, description: "second request after heartbeat") {
-            pb.capturedRequests.count >= 2
+            pb.capturedRequestCount >= 2
         }
 
         XCTAssertTrue(
@@ -296,7 +296,7 @@ final class SSEClientTests: XCTestCase {
         client.connect()
         wait(for: [opened], timeout: 3)
         // tokenProvider 실패는 request 가 만들어지기 전이라 capturedRequests 1건만.
-        XCTAssertEqual(pb.capturedRequests.count, 1)
+        XCTAssertEqual(pb.capturedRequestCount, 1)
         client.disconnect()
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
@@ -2,9 +2,6 @@
 //  SSEClientTests.swift
 //  notifly-ios-sdkTests
 //
-//  SSEClient 통합 테스트 — streamLineProvider 를 주입하여 결정적 라인 입력으로 검증.
-//  실제 URLSession.bytes 와의 결합은 production 에서만 사용하며 본 테스트는 그 위층의 동작을 검증한다.
-//
 
 import XCTest
 @testable import notifly_ios_sdk
@@ -12,186 +9,22 @@ import XCTest
 @available(iOSApplicationExtension, unavailable)
 final class SSEClientTests: XCTestCase {
 
-    // MARK: - Helpers
-
-    /// 단일 connect 시도에 대한 stream 시나리오. 테스트가 lines 를 푸시한다.
-    private final class TestStream: @unchecked Sendable {
-        let continuation: AsyncThrowingStream<String, Error>.Continuation
-        let stream: AsyncThrowingStream<String, Error>
-
-        init() {
-            var contRef: AsyncThrowingStream<String, Error>.Continuation!
-            self.stream = AsyncThrowingStream<String, Error> { c in contRef = c }
-            self.continuation = contRef
-        }
-
-        func write(_ line: String) {
-            continuation.yield(line)
-        }
-
-        func writeBlock(_ block: String) {
-            // "event: x\ndata: y\n\n" 같은 raw block 을 라인 단위로 분할하여 푸시.
-            for line in block.components(separatedBy: "\n") {
-                continuation.yield(line)
-            }
-        }
-
-        func finish() {
-            continuation.finish()
-        }
-
-        func fail(_ error: Error) {
-            continuation.finish(throwing: error)
-        }
-    }
-
-    /// connect 시도마다 다음 시나리오를 반환하는 provider 빌더.
-    /// 각 시나리오는 (statusCode, optional preset stream) 또는 외부 제어용 TestStream 을 사용.
-    private final class ProviderBuilder: @unchecked Sendable {
-        struct Scenario {
-            var statusCode: Int = 200
-            var contentType: String = "text/event-stream"
-            var stream: TestStream?
-        }
-
-        private let lock = NSLock()
-        private var scenarios: [Scenario] = []
-        private(set) var capturedRequests: [URLRequest] = []
-        var onRequest: ((URLRequest) -> Void)?
-
-        func enqueue(_ scenario: Scenario) {
-            lock.lock(); defer { lock.unlock() }
-            scenarios.append(scenario)
-        }
-
-        func enqueueOpen(stream: TestStream = TestStream()) -> TestStream {
-            enqueue(Scenario(statusCode: 200, stream: stream))
-            return stream
-        }
-
-        func enqueueOpenWithContentType(_ contentType: String, stream: TestStream = TestStream()) -> TestStream {
-            enqueue(Scenario(statusCode: 200, contentType: contentType, stream: stream))
-            return stream
-        }
-
-        func enqueueHTTPError(_ code: Int) {
-            enqueue(Scenario(statusCode: code, stream: nil))
-        }
-
-        /// non-200 success (204 등). body 비어있는 stream 으로 즉시 finish.
-        func enqueueNoContent(_ code: Int = 204) {
-            enqueue(Scenario(statusCode: code, stream: nil))
-        }
-
-        func makeProvider() -> SSEClient.StreamLineProvider {
-            return { [weak self] request in
-                guard let self = self else { throw SSEClient.ConnectionError.invalidResponse }
-                self.lock.lock()
-                self.capturedRequests.append(request)
-                let cb = self.onRequest
-                let scenario = self.scenarios.isEmpty
-                    ? Scenario(statusCode: 500, stream: nil)
-                    : self.scenarios.removeFirst()
-                self.lock.unlock()
-                cb?(request)
-
-                let response = HTTPURLResponse(
-                    url: request.url!,
-                    statusCode: scenario.statusCode,
-                    httpVersion: "HTTP/1.1",
-                    headerFields: ["Content-Type": scenario.contentType]
-                )!
-                let stream = scenario.stream?.stream ?? AsyncThrowingStream<String, Error> { c in
-                    c.finish()
-                }
-                return (response, stream)
-            }
-        }
-    }
-
-    private func makeClient(
-        deviceId: String? = "device-1",
-        backoff: [TimeInterval] = [0.05],
-        heartbeatTimeout: TimeInterval = SSEClient.defaultHeartbeatTimeout,
-        token: @escaping () async throws -> String = { "test-token" },
-        provider: @escaping SSEClient.StreamLineProvider
-    ) -> SSEClient {
-        return SSEClient(
-            projectId: "00000000000000000000000000000abc",
-            notiflyUserId: "user-42",
-            deviceId: deviceId,
-            tokenProvider: token,
-            baseURLString: "https://test.local/streams",
-            backoffSchedule: backoff,
-            heartbeatTimeout: heartbeatTimeout,
-            streamLineProvider: provider,
-            jitterProvider: { 1.0 }
-        )
-    }
-
-    private func waitForCondition(
-        timeout: TimeInterval = 3,
-        description: String = "condition",
-        _ check: @escaping () -> Bool
-    ) {
-        let exp = expectation(description: description)
-        let queue = DispatchQueue.global()
-        var fulfilled = false
-        let lock = NSLock()
-        let deadline = Date().addingTimeInterval(timeout)
-        func tick() {
-            queue.asyncAfter(deadline: .now() + 0.02) {
-                lock.lock()
-                if fulfilled {
-                    lock.unlock()
-                    return
-                }
-                lock.unlock()
-                if check() {
-                    lock.lock()
-                    if !fulfilled {
-                        fulfilled = true
-                        lock.unlock()
-                        exp.fulfill()
-                    } else {
-                        lock.unlock()
-                    }
-                    return
-                }
-                if Date() < deadline {
-                    tick()
-                } else {
-                    lock.lock()
-                    if !fulfilled {
-                        fulfilled = true
-                        lock.unlock()
-                        exp.fulfill()
-                    } else {
-                        lock.unlock()
-                    }
-                }
-            }
-        }
-        tick()
-        wait(for: [exp], timeout: timeout + 1)
-    }
-
     // MARK: - 기본
 
     func test_initialState_isIdle() {
         let pb = ProviderBuilder()
-        let client = makeClient(provider: pb.makeProvider())
+        let client = makeSSEClient(provider: pb.makeProvider())
         XCTAssertEqual(client.state, .idle)
         XCTAssertNil(client.lastEventId)
     }
 
     func test_connect_transitionsThroughConnectingToOpen() {
         let pb = ProviderBuilder()
-        _ = pb.enqueueOpen()  // connect 시도 시 .open
+        pb.enqueueOpen()
 
         let recorder = StateRecorder()
         let openExp = expectation(description: "open")
-        let client = makeClient(provider: pb.makeProvider())
+        let client = makeSSEClient(provider: pb.makeProvider())
         client.onState = { state in
             recorder.append(state)
             if state == .open { openExp.fulfill() }
@@ -213,7 +46,7 @@ final class SSEClientTests: XCTestCase {
         var receivedType: String?
         var receivedData: String?
 
-        let client = makeClient(provider: pb.makeProvider())
+        let client = makeSSEClient(provider: pb.makeProvider())
         client.onMessage = { type, data in
             receivedType = type
             receivedData = data
@@ -221,10 +54,9 @@ final class SSEClientTests: XCTestCase {
         }
         client.connect()
 
-        // .open 이 된 시점에 라인 푸시.
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
             stream.writeBlock("event: connected\ndata: {\"projectId\":\"abc\"}\n")
-            stream.write("")  // dispatch trigger
+            stream.write("")
         }
 
         wait(for: [messageExp], timeout: 3)
@@ -236,10 +68,10 @@ final class SSEClientTests: XCTestCase {
 
     func test_request_buildsBearerAndAcceptHeaders_andURLPath() {
         let pb = ProviderBuilder()
-        _ = pb.enqueueOpen()
+        pb.enqueueOpen()
 
         let opened = expectation(description: "open")
-        let client = makeClient(token: { "my-token" }, provider: pb.makeProvider())
+        let client = makeSSEClient(token: { "my-token" }, provider: pb.makeProvider())
         client.onState = { state in
             if state == .open { opened.fulfill() }
         }
@@ -259,10 +91,10 @@ final class SSEClientTests: XCTestCase {
 
     func test_request_omitsDeviceIdQueryWhenNil() {
         let pb = ProviderBuilder()
-        _ = pb.enqueueOpen()
+        pb.enqueueOpen()
 
         let opened = expectation(description: "open")
-        let client = makeClient(deviceId: nil, provider: pb.makeProvider())
+        let client = makeSSEClient(deviceId: nil, provider: pb.makeProvider())
         client.onState = { state in
             if state == .open { opened.fulfill() }
         }
@@ -278,17 +110,16 @@ final class SSEClientTests: XCTestCase {
     func test_reconnect_includesLastEventIdHeader() {
         let pb = ProviderBuilder()
         let firstStream = pb.enqueueOpen()
-        _ = pb.enqueueOpen()  // 2차 연결
+        pb.enqueueOpen()
 
         let firstReceived = expectation(description: "first event")
-        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
         client.onMessage = { _, _ in firstReceived.fulfill() }
         client.connect()
 
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
             firstStream.writeBlock("id: 42\nevent: sync\ndata: {}\n")
             firstStream.write("")
-            // stream 종료 → 재연결 유도
             DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
                 firstStream.finish()
             }
@@ -304,15 +135,15 @@ final class SSEClientTests: XCTestCase {
         client.disconnect()
     }
 
-    // MARK: - 백오프 / HTTP 에러
+    // MARK: - HTTP 에러 / 백오프
 
     func test_httpError_triggersReconnect() {
         let pb = ProviderBuilder()
         pb.enqueueHTTPError(503)
-        _ = pb.enqueueOpen()
+        pb.enqueueOpen()
 
         let recorder = StateRecorder()
-        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
         client.onState = { recorder.append($0) }
         client.connect()
 
@@ -331,77 +162,14 @@ final class SSEClientTests: XCTestCase {
         client.disconnect()
     }
 
-    func test_204NoContent_isRejectedAndBacksOff() {
-        let pb = ProviderBuilder()
-        pb.enqueueNoContent(204)
-        _ = pb.enqueueOpen()
-
-        let recorder = StateRecorder()
-        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
-        client.onState = { recorder.append($0) }
-        client.connect()
-
-        waitForCondition(description: "204 → backoff → second connect") {
-            pb.capturedRequests.count >= 2
-        }
-
-        XCTAssertTrue(
-            recorder.snapshot.contains { state in
-                if case .reconnecting = state { return true }
-                return false
-            },
-            "Expected .reconnecting after 204 in \(recorder.snapshot)"
-        )
-
-        client.disconnect()
-    }
-
-    func test_wrongContentType_isRejectedAndBacksOff() {
-        let pb = ProviderBuilder()
-        _ = pb.enqueueOpenWithContentType("application/json")
-        _ = pb.enqueueOpen()
-
-        let recorder = StateRecorder()
-        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
-        client.onState = { recorder.append($0) }
-        client.connect()
-
-        waitForCondition(description: "wrong content-type → backoff → second connect") {
-            pb.capturedRequests.count >= 2
-        }
-
-        XCTAssertTrue(
-            recorder.snapshot.contains { state in
-                if case .reconnecting = state { return true }
-                return false
-            }
-        )
-
-        client.disconnect()
-    }
-
-    func test_eventStreamWithCharsetParam_isAccepted() {
-        let pb = ProviderBuilder()
-        _ = pb.enqueueOpenWithContentType("text/event-stream; charset=utf-8")
-
-        let opened = expectation(description: "opened")
-        let client = makeClient(provider: pb.makeProvider())
-        client.onState = { state in
-            if state == .open { opened.fulfill() }
-        }
-        client.connect()
-        wait(for: [opened], timeout: 3)
-        client.disconnect()
-    }
-
     // MARK: - 멱등성 / disconnect
 
     func test_connect_isIdempotentWhileConnected() {
         let pb = ProviderBuilder()
-        _ = pb.enqueueOpen()
+        pb.enqueueOpen()
 
         let opened = expectation(description: "opened")
-        let client = makeClient(provider: pb.makeProvider())
+        let client = makeSSEClient(provider: pb.makeProvider())
         client.onState = { state in
             if state == .open { opened.fulfill() }
         }
@@ -411,7 +179,6 @@ final class SSEClientTests: XCTestCase {
         client.connect()
         client.connect()
 
-        // 짧게 대기 후 추가 요청 없는지 확인
         let assertion = expectation(description: "no extra request")
         DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
             assertion.fulfill()
@@ -424,11 +191,11 @@ final class SSEClientTests: XCTestCase {
 
     func test_disconnect_transitionsToStopped() {
         let pb = ProviderBuilder()
-        _ = pb.enqueueOpen()
+        pb.enqueueOpen()
 
         let opened = expectation(description: "opened")
         let stopped = expectation(description: "stopped")
-        let client = makeClient(provider: pb.makeProvider())
+        let client = makeSSEClient(provider: pb.makeProvider())
         client.onState = { state in
             if state == .open { opened.fulfill() }
             if state == .stopped { stopped.fulfill() }
@@ -443,16 +210,15 @@ final class SSEClientTests: XCTestCase {
 
     func test_disconnect_thenConnect_restartsLoop() {
         let pb = ProviderBuilder()
-        _ = pb.enqueueOpen()
-        _ = pb.enqueueOpen()
+        pb.enqueueOpen()
+        pb.enqueueOpen()
 
         let firstOpen = expectation(description: "first open")
         firstOpen.assertForOverFulfill = false
         let secondOpen = expectation(description: "second open")
         secondOpen.assertForOverFulfill = false
 
-        let client = makeClient(provider: pb.makeProvider())
-        // onState 는 main queue 로 dispatch 되지만 가독성/안전성을 위해 명시 동기화.
+        let client = makeSSEClient(provider: pb.makeProvider())
         let counterQueue = DispatchQueue(label: "test.openCounter")
         var seenOpenCount = 0
         client.onState = { state in
@@ -477,13 +243,11 @@ final class SSEClientTests: XCTestCase {
 
     func test_heartbeatTimeout_triggersReconnect() {
         let pb = ProviderBuilder()
-        // 1차: open 유지하되 라인 미푸시 → watchdog 가 끊는다.
-        _ = pb.enqueueOpen()
-        // 2차: 재연결 검증용
-        _ = pb.enqueueOpen()
+        pb.enqueueOpen()
+        pb.enqueueOpen()
 
         let recorder = StateRecorder()
-        let client = makeClient(
+        let client = makeSSEClient(
             backoff: [0.02],
             heartbeatTimeout: 0.3,
             provider: pb.makeProvider()
@@ -495,7 +259,6 @@ final class SSEClientTests: XCTestCase {
             pb.capturedRequests.count >= 2
         }
 
-        // heartbeat timeout 으로 .reconnecting 상태가 한 번 이상 거쳐갔는지 검증.
         XCTAssertTrue(
             recorder.snapshot.contains { state in
                 if case .reconnecting = state { return true }
@@ -507,15 +270,15 @@ final class SSEClientTests: XCTestCase {
         client.disconnect()
     }
 
-    // MARK: - 토큰 / URL 에러
+    // MARK: - 토큰 에러
 
     func test_tokenProviderThrows_loopRecoversOnNextAttempt() {
         let pb = ProviderBuilder()
-        _ = pb.enqueueOpen()  // 두 번째 시도에서는 정상 open
+        pb.enqueueOpen()
 
         var attempt = 0
         let lock = NSLock()
-        let client = makeClient(
+        let client = makeSSEClient(
             backoff: [0.02],
             token: {
                 lock.lock(); defer { lock.unlock() }
@@ -532,25 +295,8 @@ final class SSEClientTests: XCTestCase {
         }
         client.connect()
         wait(for: [opened], timeout: 3)
-        XCTAssertEqual(pb.capturedRequests.count, 1)  // token 실패 시점에는 request 안 만들어짐
+        // tokenProvider 실패는 request 가 만들어지기 전이라 capturedRequests 1건만.
+        XCTAssertEqual(pb.capturedRequests.count, 1)
         client.disconnect()
-    }
-}
-
-// MARK: - Test Utilities
-
-@available(iOSApplicationExtension, unavailable)
-final class StateRecorder: @unchecked Sendable {
-    private let lock = NSLock()
-    private var states: [SSEClient.State] = []
-
-    func append(_ s: SSEClient.State) {
-        lock.lock(); defer { lock.unlock() }
-        states.append(s)
-    }
-
-    var snapshot: [SSEClient.State] {
-        lock.lock(); defer { lock.unlock() }
-        return states
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
@@ -1,0 +1,482 @@
+//
+//  SSEClientTests.swift
+//  notifly-ios-sdkTests
+//
+//  SSEClient 통합 테스트 — streamLineProvider 를 주입하여 결정적 라인 입력으로 검증.
+//  실제 URLSession.bytes 와의 결합은 production 에서만 사용하며 본 테스트는 그 위층의 동작을 검증한다.
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEClientTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// 단일 connect 시도에 대한 stream 시나리오. 테스트가 lines 를 푸시한다.
+    private final class TestStream: @unchecked Sendable {
+        let continuation: AsyncThrowingStream<String, Error>.Continuation
+        let stream: AsyncThrowingStream<String, Error>
+
+        init() {
+            var contRef: AsyncThrowingStream<String, Error>.Continuation!
+            self.stream = AsyncThrowingStream<String, Error> { c in contRef = c }
+            self.continuation = contRef
+        }
+
+        func write(_ line: String) {
+            continuation.yield(line)
+        }
+
+        func writeBlock(_ block: String) {
+            // "event: x\ndata: y\n\n" 같은 raw block 을 라인 단위로 분할하여 푸시.
+            for line in block.components(separatedBy: "\n") {
+                continuation.yield(line)
+            }
+        }
+
+        func finish() {
+            continuation.finish()
+        }
+
+        func fail(_ error: Error) {
+            continuation.finish(throwing: error)
+        }
+    }
+
+    /// connect 시도마다 다음 시나리오를 반환하는 provider 빌더.
+    /// 각 시나리오는 (statusCode, optional preset stream) 또는 외부 제어용 TestStream 을 사용.
+    private final class ProviderBuilder: @unchecked Sendable {
+        struct Scenario {
+            var statusCode: Int = 200
+            var stream: TestStream?
+        }
+
+        private let lock = NSLock()
+        private var scenarios: [Scenario] = []
+        private(set) var capturedRequests: [URLRequest] = []
+        var onRequest: ((URLRequest) -> Void)?
+
+        func enqueue(_ scenario: Scenario) {
+            lock.lock(); defer { lock.unlock() }
+            scenarios.append(scenario)
+        }
+
+        func enqueueOpen(stream: TestStream = TestStream()) -> TestStream {
+            enqueue(Scenario(statusCode: 200, stream: stream))
+            return stream
+        }
+
+        func enqueueHTTPError(_ code: Int) {
+            enqueue(Scenario(statusCode: code, stream: nil))
+        }
+
+        func makeProvider() -> SSEClient.StreamLineProvider {
+            return { [weak self] request in
+                guard let self = self else { throw SSEClient.ConnectionError.invalidResponse }
+                self.lock.lock()
+                self.capturedRequests.append(request)
+                let cb = self.onRequest
+                let scenario = self.scenarios.isEmpty
+                    ? Scenario(statusCode: 500, stream: nil)
+                    : self.scenarios.removeFirst()
+                self.lock.unlock()
+                cb?(request)
+
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: scenario.statusCode,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "text/event-stream"]
+                )!
+                let stream = scenario.stream?.stream ?? AsyncThrowingStream<String, Error> { c in
+                    c.finish()
+                }
+                return (response, stream)
+            }
+        }
+    }
+
+    private func makeClient(
+        deviceId: String? = "device-1",
+        backoff: [TimeInterval] = [0.05],
+        heartbeatTimeout: TimeInterval = SSEClient.defaultHeartbeatTimeout,
+        token: @escaping () async throws -> String = { "test-token" },
+        provider: @escaping SSEClient.StreamLineProvider
+    ) -> SSEClient {
+        return SSEClient(
+            projectId: "00000000000000000000000000000abc",
+            notiflyUserId: "user-42",
+            deviceId: deviceId,
+            tokenProvider: token,
+            baseURLString: "https://test.local/streams",
+            backoffSchedule: backoff,
+            heartbeatTimeout: heartbeatTimeout,
+            streamLineProvider: provider,
+            jitterProvider: { 1.0 }
+        )
+    }
+
+    private func waitForCondition(
+        timeout: TimeInterval = 3,
+        description: String = "condition",
+        _ check: @escaping () -> Bool
+    ) {
+        let exp = expectation(description: description)
+        let queue = DispatchQueue.global()
+        var fulfilled = false
+        let lock = NSLock()
+        let deadline = Date().addingTimeInterval(timeout)
+        func tick() {
+            queue.asyncAfter(deadline: .now() + 0.02) {
+                lock.lock()
+                if fulfilled {
+                    lock.unlock()
+                    return
+                }
+                lock.unlock()
+                if check() {
+                    lock.lock()
+                    if !fulfilled {
+                        fulfilled = true
+                        lock.unlock()
+                        exp.fulfill()
+                    } else {
+                        lock.unlock()
+                    }
+                    return
+                }
+                if Date() < deadline {
+                    tick()
+                } else {
+                    lock.lock()
+                    if !fulfilled {
+                        fulfilled = true
+                        lock.unlock()
+                        exp.fulfill()
+                    } else {
+                        lock.unlock()
+                    }
+                }
+            }
+        }
+        tick()
+        wait(for: [exp], timeout: timeout + 1)
+    }
+
+    // MARK: - 기본
+
+    func test_initialState_isIdle() {
+        let pb = ProviderBuilder()
+        let client = makeClient(provider: pb.makeProvider())
+        XCTAssertEqual(client.state, .idle)
+        XCTAssertNil(client.lastEventId)
+    }
+
+    func test_connect_transitionsThroughConnectingToOpen() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpen()  // connect 시도 시 .open
+
+        let recorder = StateRecorder()
+        let openExp = expectation(description: "open")
+        let client = makeClient(provider: pb.makeProvider())
+        client.onState = { state in
+            recorder.append(state)
+            if state == .open { openExp.fulfill() }
+        }
+        client.connect()
+        wait(for: [openExp], timeout: 3)
+
+        XCTAssertEqual(recorder.snapshot.first, .connecting)
+        XCTAssertTrue(recorder.snapshot.contains(.open))
+
+        client.disconnect()
+    }
+
+    func test_connect_emitsMessageOnReceivedEvent() {
+        let pb = ProviderBuilder()
+        let stream = pb.enqueueOpen()
+
+        let messageExp = expectation(description: "message")
+        var receivedType: String?
+        var receivedData: String?
+
+        let client = makeClient(provider: pb.makeProvider())
+        client.onMessage = { type, data in
+            receivedType = type
+            receivedData = data
+            messageExp.fulfill()
+        }
+        client.connect()
+
+        // .open 이 된 시점에 라인 푸시.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+            stream.writeBlock("event: connected\ndata: {\"projectId\":\"abc\"}\n")
+            stream.write("")  // dispatch trigger
+        }
+
+        wait(for: [messageExp], timeout: 3)
+        XCTAssertEqual(receivedType, "connected")
+        XCTAssertEqual(receivedData, "{\"projectId\":\"abc\"}")
+
+        client.disconnect()
+    }
+
+    func test_request_buildsBearerAndAcceptHeaders_andURLPath() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpen()
+
+        let opened = expectation(description: "open")
+        let client = makeClient(token: { "my-token" }, provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+
+        let captured = pb.capturedRequests.first
+        XCTAssertNotNil(captured)
+        XCTAssertEqual(captured?.value(forHTTPHeaderField: "Authorization"), "Bearer my-token")
+        XCTAssertEqual(captured?.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+        XCTAssertNil(captured?.value(forHTTPHeaderField: "Last-Event-ID"))
+        XCTAssertEqual(captured?.url?.path, "/streams/00000000000000000000000000000abc/user-42")
+        XCTAssertEqual(captured?.url?.query, "deviceId=device-1")
+
+        client.disconnect()
+    }
+
+    func test_request_omitsDeviceIdQueryWhenNil() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpen()
+
+        let opened = expectation(description: "open")
+        let client = makeClient(deviceId: nil, provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+
+        XCTAssertNil(pb.capturedRequests.first?.url?.query)
+        client.disconnect()
+    }
+
+    // MARK: - Last-Event-ID 재연결
+
+    func test_reconnect_includesLastEventIdHeader() {
+        let pb = ProviderBuilder()
+        let firstStream = pb.enqueueOpen()
+        _ = pb.enqueueOpen()  // 2차 연결
+
+        let firstReceived = expectation(description: "first event")
+        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onMessage = { _, _ in firstReceived.fulfill() }
+        client.connect()
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+            firstStream.writeBlock("id: 42\nevent: sync\ndata: {}\n")
+            firstStream.write("")
+            // stream 종료 → 재연결 유도
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                firstStream.finish()
+            }
+        }
+
+        wait(for: [firstReceived], timeout: 3)
+        waitForCondition(description: "second request") { pb.capturedRequests.count >= 2 }
+
+        let secondRequest = pb.capturedRequests[1]
+        XCTAssertEqual(secondRequest.value(forHTTPHeaderField: "Last-Event-ID"), "42")
+        XCTAssertEqual(client.lastEventId, "42")
+
+        client.disconnect()
+    }
+
+    // MARK: - 백오프 / HTTP 에러
+
+    func test_httpError_triggersReconnect() {
+        let pb = ProviderBuilder()
+        pb.enqueueHTTPError(503)
+        _ = pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "second request after 503") {
+            pb.capturedRequests.count >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            },
+            "Expected .reconnecting in \(recorder.snapshot)"
+        )
+
+        client.disconnect()
+    }
+
+    // MARK: - 멱등성 / disconnect
+
+    func test_connect_isIdempotentWhileConnected() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpen()
+
+        let opened = expectation(description: "opened")
+        let client = makeClient(provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+
+        client.connect()
+        client.connect()
+
+        // 짧게 대기 후 추가 요청 없는지 확인
+        let assertion = expectation(description: "no extra request")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            assertion.fulfill()
+        }
+        wait(for: [assertion], timeout: 2)
+        XCTAssertEqual(pb.capturedRequests.count, 1)
+
+        client.disconnect()
+    }
+
+    func test_disconnect_transitionsToStopped() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpen()
+
+        let opened = expectation(description: "opened")
+        let stopped = expectation(description: "stopped")
+        let client = makeClient(provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+            if state == .stopped { stopped.fulfill() }
+        }
+
+        client.connect()
+        wait(for: [opened], timeout: 3)
+        client.disconnect()
+        wait(for: [stopped], timeout: 3)
+        XCTAssertEqual(client.state, .stopped)
+    }
+
+    func test_disconnect_thenConnect_restartsLoop() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpen()
+        _ = pb.enqueueOpen()
+
+        let firstOpen = expectation(description: "first open")
+        firstOpen.assertForOverFulfill = false
+        let secondOpen = expectation(description: "second open")
+        secondOpen.assertForOverFulfill = false
+
+        let client = makeClient(provider: pb.makeProvider())
+        // onState 는 main queue 로 dispatch 되지만 가독성/안전성을 위해 명시 동기화.
+        let counterQueue = DispatchQueue(label: "test.openCounter")
+        var seenOpenCount = 0
+        client.onState = { state in
+            guard state == .open else { return }
+            counterQueue.sync {
+                seenOpenCount += 1
+                if seenOpenCount == 1 { firstOpen.fulfill() }
+                if seenOpenCount == 2 { secondOpen.fulfill() }
+            }
+        }
+        client.connect()
+        wait(for: [firstOpen], timeout: 3)
+        client.disconnect()
+        client.connect()
+        wait(for: [secondOpen], timeout: 3)
+
+        XCTAssertEqual(pb.capturedRequests.count, 2)
+        client.disconnect()
+    }
+
+    // MARK: - Heartbeat watchdog
+
+    func test_heartbeatTimeout_triggersReconnect() {
+        let pb = ProviderBuilder()
+        // 1차: open 유지하되 라인 미푸시 → watchdog 가 끊는다.
+        _ = pb.enqueueOpen()
+        // 2차: 재연결 검증용
+        _ = pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeClient(
+            backoff: [0.02],
+            heartbeatTimeout: 0.3,
+            provider: pb.makeProvider()
+        )
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(timeout: 5, description: "second request after heartbeat") {
+            pb.capturedRequests.count >= 2
+        }
+
+        // heartbeat timeout 으로 .reconnecting 상태가 한 번 이상 거쳐갔는지 검증.
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            },
+            "Expected .reconnecting after heartbeat timeout in \(recorder.snapshot)"
+        )
+
+        client.disconnect()
+    }
+
+    // MARK: - 토큰 / URL 에러
+
+    func test_tokenProviderThrows_loopRecoversOnNextAttempt() {
+        let pb = ProviderBuilder()
+        _ = pb.enqueueOpen()  // 두 번째 시도에서는 정상 open
+
+        var attempt = 0
+        let lock = NSLock()
+        let client = makeClient(
+            backoff: [0.02],
+            token: {
+                lock.lock(); defer { lock.unlock() }
+                attempt += 1
+                if attempt == 1 { throw NSError(domain: "Test", code: 1) }
+                return "ok-token"
+            },
+            provider: pb.makeProvider()
+        )
+
+        let opened = expectation(description: "opened on retry")
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+        XCTAssertEqual(pb.capturedRequests.count, 1)  // token 실패 시점에는 request 안 만들어짐
+        client.disconnect()
+    }
+}
+
+// MARK: - Test Utilities
+
+@available(iOSApplicationExtension, unavailable)
+final class StateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [SSEClient.State] = []
+
+    func append(_ s: SSEClient.State) {
+        lock.lock(); defer { lock.unlock() }
+        states.append(s)
+    }
+
+    var snapshot: [SSEClient.State] {
+        lock.lock(); defer { lock.unlock() }
+        return states
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSELineParserTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSELineParserTests.swift
@@ -1,0 +1,215 @@
+//
+//  SSELineParserTests.swift
+//  notifly-ios-sdkTests
+//
+//  WHATWG SSE 스펙 핵심 룰을 라인 단위로 검증.
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+final class SSELineParserTests: XCTestCase {
+
+    // MARK: - 기본 dispatch
+
+    func test_singleEvent_withTypeAndData_dispatchOnEmptyLine() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("event: sync"))
+        XCTAssertNil(p.feed("data: {\"ts\":1}"))
+
+        let event = p.feed("")
+        XCTAssertEqual(event, SSEEvent(id: nil, type: "sync", data: "{\"ts\":1}"))
+    }
+
+    func test_dataOnly_typeDefaultsToMessage() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("data: hello"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "hello"))
+    }
+
+    func test_emptyData_doesNotDispatch() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("event: sync"))
+        XCTAssertNil(p.feed(""))   // data 없으면 dispatch X
+    }
+
+    func test_lineWithNoColon_treatedAsFieldNameWithEmptyValue() {
+        let p = SSELineParser()
+        // "data" 라인은 field=data, value="" → 빈 data 라인 1개 누적
+        XCTAssertNil(p.feed("data"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: ""))
+    }
+
+    // MARK: - data 멀티라인
+
+    func test_multipleDataLines_joinedWithNewline() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("data: line1"))
+        XCTAssertNil(p.feed("data: line2"))
+        XCTAssertNil(p.feed("data:line3"))   // 콜론 뒤 공백 없는 케이스
+        XCTAssertEqual(
+            p.feed(""),
+            SSEEvent(id: nil, type: "message", data: "line1\nline2\nline3")
+        )
+    }
+
+    // MARK: - comment / heartbeat
+
+    func test_commentLine_ignoredAndDoesNotDispatch() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed(": heartbeat"))
+        XCTAssertNil(p.feed(":"))
+        XCTAssertNil(p.feed("data: hi"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "hi"))
+    }
+
+    // MARK: - id 처리
+
+    func test_idField_setsLastEventIdAndIsAttachedToDispatchedEvent() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("id: 42"))
+        XCTAssertNil(p.feed("data: x"))
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "42")
+        XCTAssertEqual(p.lastEventId, "42")
+    }
+
+    func test_idBufferPersists_acrossEventsWhenNotResent() {
+        let p = SSELineParser()
+        // 첫 이벤트: id 명시
+        _ = p.feed("id: 7")
+        _ = p.feed("data: a")
+        let first = p.feed("")
+        XCTAssertEqual(first?.id, "7")
+
+        // 다음 이벤트: id 라인 없음 → 직전 buffer "7" 그대로 attach
+        _ = p.feed("data: b")
+        let second = p.feed("")
+        XCTAssertEqual(second?.id, "7")
+        XCTAssertEqual(p.lastEventId, "7")
+    }
+
+    func test_idEmptyValue_resetsBufferToEmptyString() {
+        let p = SSELineParser()
+        _ = p.feed("id: 5")
+        _ = p.feed("data: a")
+        _ = p.feed("")
+        XCTAssertEqual(p.lastEventId, "5")
+
+        // id: (빈 값) → buffer 를 "" 로 갱신
+        _ = p.feed("id:")
+        _ = p.feed("data: b")
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "")
+        XCTAssertEqual(p.lastEventId, "")
+    }
+
+    func test_idWithNullByte_isIgnored() {
+        let p = SSELineParser()
+        _ = p.feed("id: ok")
+        _ = p.feed("data: a")
+        _ = p.feed("")
+        XCTAssertEqual(p.lastEventId, "ok")
+
+        // U+0000 포함 → 무시 (buffer 유지)
+        _ = p.feed("id: bad\u{0000}value")
+        _ = p.feed("data: b")
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "ok")
+        XCTAssertEqual(p.lastEventId, "ok")
+    }
+
+    // MARK: - retry / unknown field
+
+    func test_retryField_isIgnored() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("retry: 5000"))
+        XCTAssertNil(p.feed("data: x"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "x"))
+    }
+
+    func test_unknownField_isIgnored() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("custom: whatever"))
+        XCTAssertNil(p.feed("data: x"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "x"))
+    }
+
+    // MARK: - line ending / BOM
+
+    func test_trailingCarriageReturn_isStripped() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("event: sync\r"))
+        XCTAssertNil(p.feed("data: payload\r"))
+        XCTAssertEqual(p.feed("\r"), SSEEvent(id: nil, type: "sync", data: "payload"))
+    }
+
+    func test_bomAtStart_isStripped() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("\u{FEFF}event: sync"))
+        XCTAssertNil(p.feed("data: x"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "sync", data: "x"))
+    }
+
+    func test_bom_onlyStrippedFromFirstLine_preservedInDataValueAfter() {
+        let p = SSELineParser()
+        // 첫 라인의 BOM 은 제거.
+        XCTAssertNil(p.feed("\u{FEFF}event: msg"))
+        // 이후 라인의 U+FEFF 는 데이터 일부로 보존.
+        XCTAssertNil(p.feed("data: \u{FEFF}value"))
+        XCTAssertEqual(p.feed("")?.data, "\u{FEFF}value")
+    }
+
+    // MARK: - 콜론 뒤 공백 처리
+
+    func test_singleLeadingSpace_isStripped() {
+        let p = SSELineParser()
+        _ = p.feed("data: x")  // " x" 가 아니라 "x"
+        XCTAssertEqual(p.feed("")?.data, "x")
+    }
+
+    func test_multipleLeadingSpaces_onlyOneStripped() {
+        let p = SSELineParser()
+        _ = p.feed("data:  x")  // 첫 공백만 제거 → " x" 보존
+        XCTAssertEqual(p.feed("")?.data, " x")
+    }
+
+    func test_noLeadingSpace_valuePreserved() {
+        let p = SSELineParser()
+        _ = p.feed("data:x")
+        XCTAssertEqual(p.feed("")?.data, "x")
+    }
+
+    // MARK: - 통합 시나리오
+
+    func test_typicalServerSentSequence() {
+        let p = SSELineParser()
+        // connected
+        _ = p.feed(": stream opened")        // comment
+        _ = p.feed("event: connected")
+        _ = p.feed("data: {\"projectId\":\"abc\"}")
+        let connected = p.feed("")
+        XCTAssertEqual(connected?.type, "connected")
+
+        // sync (with id)
+        _ = p.feed("id: 42")
+        _ = p.feed("event: sync")
+        _ = p.feed("data: {}")
+        let sync = p.feed("")
+        XCTAssertEqual(sync, SSEEvent(id: "42", type: "sync", data: "{}"))
+
+        // heartbeat
+        _ = p.feed(": heartbeat")
+        XCTAssertNil(p.feed(""))   // dispatch 시도하지만 data 비어 dispatch 안 됨
+
+        // server-event with multiline data
+        _ = p.feed("id: 43")
+        _ = p.feed("event: server-event")
+        _ = p.feed("data: {\"name\":\"order_completed\",")
+        _ = p.feed("data:  \"eventParams\":{}}")
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "43")
+        XCTAssertEqual(event?.type, "server-event")
+        XCTAssertEqual(event?.data, "{\"name\":\"order_completed\",\n \"eventParams\":{}}")
+    }
+}


### PR DESCRIPTION
## Summary

서버→SDK 실시간 채널 (SSE) 의 트랜스포트 레이어 구현. NOTIFLY-835.

- `SSEEvent` / `SSELineParser` / `SSEClient` 추가
- `NotiflyConstant.EndPoint.streamEndPoint = https://api.notifly.tech/streams` 도입

## 동작 요약

- **파서**: WHATWG SSE 스펙 (id/event/data, multi-line data join, BOM 첫라인 strip, comment, retry 무시, leading-space 1 trim, U+0000 id 무시)
- **트랜스포트**: `URLSession.bytes(for:).lines` + `AsyncSequence`. `streamLineProvider` DI 로 테스트 결정성 확보
- **재연결**: 지수 백오프 1/2/4/8/30s ± 20% jitter. `.open` 30s 안정 시 attempt 리셋 (정상 운영 후 끊김 → 다음 attempt 1s 부터)
- **Heartbeat watchdog**: 60s 무수신 시 reconnect. TaskGroup 으로 stream consume + watchdog 동시 실행, 첫 완료 시 나머지 cancel (structured concurrency)
- **Last-Event-ID**: 수신 시 자동 보관, 재연결 시 헤더 부착 → 서버 30s replay 버퍼 활용
- **상태 머신**: `idle / connecting / open / reconnecting(N) / stopped`. `.stopped` 흡수 상태. `connect()` 멱등 (`.connecting/.open/.reconnecting` 시 무시)
- **동시성**: 직렬 `DispatchQueue` 로 상태 동기화 (UserStateManager 등 기존 매니저와 동일 컨벤션). 콜백은 main queue dispatch
- **SDK 안전성**: invalid baseURL → connect 시 `invalidURL` throw 후 백오프. `fatalError` / force-unwrap 사용 X (host app crash 회피)

## 스코프

본 PR 은 **트랜스포트 한정**. 다음 항목은 후속 티켓:
- 라이프사이클 옵저버 (foreground/background) + Notifly singleton wiring
- `sync` / `event` / `shutdown` / `ttl-expired` 메시지 라우팅 + Fallback 모드
- 사용자 식별 변경 시 reconnect

## 테스트

- `SSELineParserTests` 19 cases — 스펙 엣지케이스 전수 (BOM 첫라인만, U+0000 id 무시, multi-line data, comment, retry 무시, line ending 변형 등)
- `SSEClientTests` 12 cases — 상태 전이, 헤더 빌드, Last-Event-ID 재연결, HTTP 에러 백오프, heartbeat timeout, connect 멱등성, disconnect→connect 재시작, token throw 복구
- 전체 47/47 통과 (기존 회귀 없음)

## Test plan

- [x] 단위 테스트 47/47 통과 (xcodebuild test, iPhone 17 Simulator iOS latest)
- [x] NotiflyTestApp 빌드 통과
- [x] App Extension 격리 (`@available(iOSApplicationExtension, unavailable)`)
- [x] 네트워크 끊김 → 백오프 재연결 (단위 테스트로 검증)
- [x] heartbeat 미수신 → 재연결 (단위 테스트로 검증)
- [ ] 실서버 (stage / prod) 통합 검증 — 후속 라이프사이클 티켓에서 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Server-Sent Events(SSE) 기반 실시간 이벤트 스트리밍 추가(연결 상태 관리, 메시지/상태 콜백, Last-Event-ID 유지, 하트비트 감지, 재연결·지수 백오프)
  * 스트림 엔드포인트 상수 추가

* **테스트**
  * SSE 라인 파서와 클라이언트용 광범위한 단위·통합 테스트 추가(파싱 규칙, 요청/응답 검증, 재연결·백오프, 하트비트, 토큰 실패 복구)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->