### PR TITLE
feat: SSE sync/event 수신 처리 + Fallback

### DIFF
--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -18,14 +18,18 @@
 		673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */; };
 		673F0EBB29EC610400814217 /* Notifly+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */; };
 		8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EB4E2A48E97C9719C16565 /* SSELineParser.swift */; };
+		A86C7442166A9C64FEC1DDB7 /* SSEMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */; };
 		AA00000000000001 /* NotiflyLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000002 /* NotiflyLinkHelper.swift */; };
 		AA00000000000003 /* ApplicationBinary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000004 /* ApplicationBinary.swift */; };
 		AA00000000000005 /* EntitlementsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000006 /* EntitlementsReader.swift */; };
 		AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000011 /* NotiflyLinkHelperTests.swift */; };
+		AB9D9076100F90E306A0CAE0 /* SSEController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB7ADB011179147141734D5 /* SSEController.swift */; };
 		AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF8FB665159427B654E3954 /* SSEClient.swift */; };
 		B0521E422C1B572100D4E357 /* Timezone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0521E412C1B572100D4E357 /* Timezone.swift */; };
 		B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */; };
+		CE59D0CEAFC4E9DFE98E831B /* SSEMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F73731CE6187DC3BD9A3F5 /* SSEMessage.swift */; };
 		D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */; };
+		E8D7CCFF63B1227A9060F876 /* SSEControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */; };
 		F2E6697B2ADE600000DF9CA0 /* NotiflyExtensionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */; };
 		F2E6697C2ADE600000DF9CA0 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */; };
 		F2E6698F2ADE602900DF9CA0 /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697F2ADE602900DF9CA0 /* NotificationsManager.swift */; };
@@ -66,10 +70,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		24F73731CE6187DC3BD9A3F5 /* SSEMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEMessage.swift; sourceTree = "<group>"; };
 		2B91499B2BDA3C3A0066CDD0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncWorker.swift; sourceTree = "<group>"; };
 		2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		2CC56C102B6001B31A226813 /* SSELineParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParserTests.swift; sourceTree = "<group>"; };
+		2DB7ADB011179147141734D5 /* SSEController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEController.swift; sourceTree = "<group>"; };
 		4DF8FB665159427B654E3954 /* SSEClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClient.swift; sourceTree = "<group>"; };
 		58EB4E2A48E97C9719C16565 /* SSELineParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParser.swift; sourceTree = "<group>"; };
 		673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = notifly_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,6 +83,8 @@
 		673F0E8A29EBA7D200814217 /* notifly-ios-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "notifly-ios-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notifly_ios_sdkTests.swift; sourceTree = "<group>"; };
 		673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notifly+PublicAPI.swift"; sourceTree = "<group>"; };
+		69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEControllerTests.swift; sourceTree = "<group>"; };
+		791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEMessageTests.swift; sourceTree = "<group>"; };
 		7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientResponseValidationTests.swift; sourceTree = "<group>"; };
 		8088603A8294AD238004B695 /* SSEClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientTests.swift; sourceTree = "<group>"; };
 		8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEEvent.swift; sourceTree = "<group>"; };
@@ -142,6 +150,8 @@
 				8088603A8294AD238004B695 /* SSEClientTests.swift */,
 				99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */,
 				7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */,
+				791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */,
+				69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */,
 			);
 			name = SSE;
 			path = SSE;
@@ -153,6 +163,8 @@
 				8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */,
 				58EB4E2A48E97C9719C16565 /* SSELineParser.swift */,
 				4DF8FB665159427B654E3954 /* SSEClient.swift */,
+				24F73731CE6187DC3BD9A3F5 /* SSEMessage.swift */,
+				2DB7ADB011179147141734D5 /* SSEController.swift */,
 			);
 			name = SSE;
 			path = SSE;
@@ -478,6 +490,8 @@
 				B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */,
 				8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */,
 				AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */,
+				CE59D0CEAFC4E9DFE98E831B /* SSEMessage.swift in Sources */,
+				AB9D9076100F90E306A0CAE0 /* SSEController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -491,6 +505,8 @@
 				1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */,
 				4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */,
 				D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */,
+				A86C7442166A9C64FEC1DDB7 /* SSEMessageTests.swift in Sources */,
+				E8D7CCFF63B1227A9060F876 /* SSEControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
@@ -38,8 +38,6 @@ class UserStateManager {
     private var eventDataAccessQueue = DispatchQueue(
         label: "com.yourapp.userStateManager.eventDataAccessQueue"
     )
-    private let syncStateGuardQueue = DispatchQueue(label: "com.notifly.userStateManager.syncStateGuardQueue")
-    private var _isSyncing: Bool = false
 
     var campaignData: CampaignData {
         get {
@@ -109,27 +107,6 @@ class UserStateManager {
             return
         }
 
-        let alreadyInFlight: Bool = syncStateGuardQueue.sync {
-            if _isSyncing {
-                return true
-            }
-            _isSyncing = true
-            return false
-        }
-        if alreadyInFlight {
-            Logger.info("syncState skipped: already in flight")
-            completion()
-            return
-        }
-
-        let clearInFlight: () -> Void = { [weak self] in
-            self?.syncStateGuardQueue.sync { self?._isSyncing = false }
-        }
-        // mismatch 분기에서 nested syncState 가 새 in-flight 를 셋업하면 outer receiveCompletion
-        // 의 clearInFlight 가 그 nested in-flight 를 race 로 해제할 수 있음 → mismatch 처리 후엔 skip.
-        let guardQueue = self.syncStateGuardQueue
-        var mismatchHandled = false
-
         let syncStateTask = NotiflyAPI().requestSyncState(
             projectId: projectId,
             notiflyUserID: notiflyUserID,
@@ -139,10 +116,6 @@ class UserStateManager {
             receiveCompletion: { syncStateCompletion in
                 if case let .failure(error) = syncStateCompletion {
                     Logger.error("Fail to sync user state: " + error.localizedDescription)
-                }
-                let skip = guardQueue.sync { mismatchHandled }
-                if !skip {
-                    clearInFlight()
                 }
             },
             receiveValue: { [weak self] jsonString in
@@ -187,9 +160,6 @@ class UserStateManager {
                         // SDK의 external_user_id를 DB 값으로 변경
                         notifly.userManager.changeExternalUserId(newValue: deviceExternalUserID)
 
-                        // nested syncState 가 가드에서 skip 되지 않도록 outer in-flight 해제.
-                        clearInFlight()
-                        guardQueue.sync { mismatchHandled = true }
                         notifly.inAppMessageManager.userStateManager.syncState(
                             postProcessConfig: PostProcessConfigForSyncState(
                                 merge: false,
@@ -210,7 +180,6 @@ class UserStateManager {
 
         guard let main = try? Notifly.main, syncStateTask != nil else {
             Logger.error("Fail to sync user state: Notifly is not initialized")
-            clearInFlight()
             completion()
             return
         }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/InAppMessage/UserStateManager.swift
@@ -38,6 +38,8 @@ class UserStateManager {
     private var eventDataAccessQueue = DispatchQueue(
         label: "com.yourapp.userStateManager.eventDataAccessQueue"
     )
+    private let syncStateGuardQueue = DispatchQueue(label: "com.notifly.userStateManager.syncStateGuardQueue")
+    private var _isSyncing: Bool = false
 
     var campaignData: CampaignData {
         get {
@@ -107,6 +109,27 @@ class UserStateManager {
             return
         }
 
+        let alreadyInFlight: Bool = syncStateGuardQueue.sync {
+            if _isSyncing {
+                return true
+            }
+            _isSyncing = true
+            return false
+        }
+        if alreadyInFlight {
+            Logger.info("syncState skipped: already in flight")
+            completion()
+            return
+        }
+
+        let clearInFlight: () -> Void = { [weak self] in
+            self?.syncStateGuardQueue.sync { self?._isSyncing = false }
+        }
+        // mismatch 분기에서 nested syncState 가 새 in-flight 를 셋업하면 outer receiveCompletion
+        // 의 clearInFlight 가 그 nested in-flight 를 race 로 해제할 수 있음 → mismatch 처리 후엔 skip.
+        let guardQueue = self.syncStateGuardQueue
+        var mismatchHandled = false
+
         let syncStateTask = NotiflyAPI().requestSyncState(
             projectId: projectId,
             notiflyUserID: notiflyUserID,
@@ -116,6 +139,10 @@ class UserStateManager {
             receiveCompletion: { syncStateCompletion in
                 if case let .failure(error) = syncStateCompletion {
                     Logger.error("Fail to sync user state: " + error.localizedDescription)
+                }
+                let skip = guardQueue.sync { mismatchHandled }
+                if !skip {
+                    clearInFlight()
                 }
             },
             receiveValue: { [weak self] jsonString in
@@ -160,6 +187,9 @@ class UserStateManager {
                         // SDK의 external_user_id를 DB 값으로 변경
                         notifly.userManager.changeExternalUserId(newValue: deviceExternalUserID)
 
+                        // nested syncState 가 가드에서 skip 되지 않도록 outer in-flight 해제.
+                        clearInFlight()
+                        guardQueue.sync { mismatchHandled = true }
                         notifly.inAppMessageManager.userStateManager.syncState(
                             postProcessConfig: PostProcessConfigForSyncState(
                                 merge: false,
@@ -180,6 +210,7 @@ class UserStateManager {
 
         guard let main = try? Notifly.main, syncStateTask != nil else {
             Logger.error("Fail to sync user state: Notifly is not initialized")
+            clearInFlight()
             completion()
             return
         }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
@@ -28,6 +28,7 @@ final class SSEController: @unchecked Sendable {
     private var _hasReachedOpen: Bool = false
     private var _pendingSyncDispatch: Bool = false
     private var _syncInFlight: Bool = false
+    private var _generation: Int = 0
 
     // MARK: - Init
 
@@ -63,6 +64,7 @@ final class SSEController: @unchecked Sendable {
     }
 
     func stop() {
+        stateQueue.sync { _generation += 1 }
         sseClient.disconnect()
     }
 
@@ -147,9 +149,13 @@ final class SSEController: @unchecked Sendable {
     private func handleShutdown(reconnectInMs: Int) {
         Logger.info("SSE shutdown received, reconnect in \(reconnectInMs)ms")
         sseClient.disconnect()
+        let scheduledGen = stateQueue.sync { _generation }
         let delay = max(TimeInterval(reconnectInMs) / 1000.0, 0)
         scheduler(delay) { [weak self] in
-            self?.sseClient.connect()
+            guard let self = self else { return }
+            let currentGen = self.stateQueue.sync { self._generation }
+            guard currentGen == scheduledGen else { return }
+            self.sseClient.connect()
         }
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
@@ -1,0 +1,151 @@
+//
+//  SSEController.swift
+//  notifly-ios-sdk
+//
+
+import Foundation
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEController: @unchecked Sendable {
+
+    enum Mode: Equatable {
+        case sse
+        case fallback
+    }
+
+    // MARK: - Configuration
+
+    let sseClient: SSEClient
+    private let onSyncRequested: (@escaping () -> Void) -> Void
+    private let onServerEventTriggered: (_ name: String, _ eventParams: [String: Any]?) -> Void
+    private let scheduler: (TimeInterval, @escaping () -> Void) -> Void
+    private let syncDebounceInterval: TimeInterval
+
+    // MARK: - State
+
+    private let stateQueue = DispatchQueue(label: "com.notifly.sse.controllerStateQueue")
+    private var _mode: Mode = .sse
+    private var _hasReachedOpen: Bool = false
+    private var _pendingSyncDispatch: Bool = false
+
+    // MARK: - Init
+
+    init(
+        sseClient: SSEClient,
+        onSyncRequested: @escaping (@escaping () -> Void) -> Void,
+        onServerEventTriggered: @escaping (_ name: String, _ eventParams: [String: Any]?) -> Void,
+        syncDebounceInterval: TimeInterval = 1.0,
+        scheduler: @escaping (TimeInterval, @escaping () -> Void) -> Void = SSEController.defaultScheduler
+    ) {
+        self.sseClient = sseClient
+        self.onSyncRequested = onSyncRequested
+        self.onServerEventTriggered = onServerEventTriggered
+        self.syncDebounceInterval = syncDebounceInterval
+        self.scheduler = scheduler
+
+        sseClient.onMessage = { [weak self] type, data in
+            self?.handleMessage(type: type, data: data)
+        }
+        sseClient.onState = { [weak self] state in
+            self?.handleStateChange(state)
+        }
+    }
+
+    static let defaultScheduler: (TimeInterval, @escaping () -> Void) -> Void = { delay, work in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    // MARK: - Public API
+
+    func start() {
+        sseClient.connect()
+    }
+
+    func stop() {
+        sseClient.disconnect()
+    }
+
+    func reconnect(reason: String) {
+        Logger.info("SSE reconnect requested: \(reason)")
+        sseClient.disconnect()
+        sseClient.connect()
+    }
+
+    var mode: Mode {
+        stateQueue.sync { _mode }
+    }
+
+    // MARK: - Internal handlers
+
+    func handleMessage(type: String, data: String) {
+        let message = SSEMessage.decode(type: type, data: data)
+        switch message {
+        case .connected:
+            stateQueue.sync {
+                _hasReachedOpen = true
+                _mode = .sse
+            }
+        case .sync:
+            triggerSyncStateDebounced()
+        case .event(let name, let params):
+            onServerEventTriggered(name, params)
+        case .shutdown(let ms):
+            handleShutdown(reconnectInMs: ms)
+        case .ttlExpired:
+            reconnect(reason: "ttl-expired")
+        case .unknown(let raw):
+            Logger.info("SSE unknown message type: \(raw)")
+        case .malformed(let raw):
+            Logger.error("SSE malformed message: type=\(raw)")
+        }
+    }
+
+    func handleStateChange(_ state: SSEClient.State) {
+        switch state {
+        case .open:
+            stateQueue.sync {
+                _hasReachedOpen = true
+                _mode = .sse
+            }
+        case .reconnecting(let attempt):
+            let shouldFallback: Bool = stateQueue.sync {
+                guard !_hasReachedOpen, attempt >= 3, _mode != .fallback else { return false }
+                _mode = .fallback
+                return true
+            }
+            if shouldFallback {
+                Logger.info("SSE entering fallback mode (attempt=\(attempt))")
+                sseClient.disconnect()
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - Private
+
+    private func triggerSyncStateDebounced() {
+        let shouldDispatchNow: Bool = stateQueue.sync {
+            if _pendingSyncDispatch {
+                return false
+            }
+            _pendingSyncDispatch = true
+            return true
+        }
+        guard shouldDispatchNow else { return }
+
+        onSyncRequested { }
+        scheduler(syncDebounceInterval) { [weak self] in
+            self?.stateQueue.sync { self?._pendingSyncDispatch = false }
+        }
+    }
+
+    private func handleShutdown(reconnectInMs: Int) {
+        Logger.info("SSE shutdown received, reconnect in \(reconnectInMs)ms")
+        sseClient.disconnect()
+        let delay = max(TimeInterval(reconnectInMs) / 1000.0, 0)
+        scheduler(delay) { [weak self] in
+            self?.sseClient.connect()
+        }
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
@@ -27,6 +27,7 @@ final class SSEController: @unchecked Sendable {
     private var _mode: Mode = .sse
     private var _hasReachedOpen: Bool = false
     private var _pendingSyncDispatch: Bool = false
+    private var _syncInFlight: Bool = false
 
     // MARK: - Init
 
@@ -126,15 +127,18 @@ final class SSEController: @unchecked Sendable {
 
     private func triggerSyncStateDebounced() {
         let shouldDispatchNow: Bool = stateQueue.sync {
-            if _pendingSyncDispatch {
+            if _pendingSyncDispatch || _syncInFlight {
                 return false
             }
             _pendingSyncDispatch = true
+            _syncInFlight = true
             return true
         }
         guard shouldDispatchNow else { return }
 
-        onSyncRequested { }
+        onSyncRequested { [weak self] in
+            self?.stateQueue.sync { self?._syncInFlight = false }
+        }
         scheduler(syncDebounceInterval) { [weak self] in
             self?.stateQueue.sync { self?._pendingSyncDispatch = false }
         }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEMessage.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEMessage.swift
@@ -1,0 +1,49 @@
+//
+//  SSEMessage.swift
+//  notifly-ios-sdk
+//
+
+import Foundation
+
+enum SSEMessage {
+    case connected
+    case sync
+    case event(name: String, eventParams: [String: Any]?)
+    case shutdown(reconnectInMs: Int)
+    case ttlExpired
+    case unknown(rawType: String)
+    case malformed(rawType: String)
+
+    static func decode(type: String, data: String) -> SSEMessage {
+        switch type {
+        case "connected":
+            return .connected
+        case "sync":
+            return .sync
+        case "server-event":
+            guard let json = parseJSON(data),
+                  let name = json["name"] as? String else {
+                return .malformed(rawType: type)
+            }
+            let params = json["eventParams"] as? [String: Any]
+            return .event(name: name, eventParams: params)
+        case "shutdown":
+            // Int / Double / NSNumber 모두 허용 (서버가 1000 또는 1000.0 둘 다 보낼 수 있음).
+            let raw = parseJSON(data)?["reconnectInMs"]
+            let ms: Int = (raw as? Int)
+                ?? (raw as? NSNumber)?.intValue
+                ?? (raw as? Double).map { Int($0) }
+                ?? 0
+            return .shutdown(reconnectInMs: max(ms, 0))
+        case "ttl-expired":
+            return .ttlExpired
+        default:
+            return .unknown(rawType: type)
+        }
+    }
+
+    private static func parseJSON(_ data: String) -> [String: Any]? {
+        guard let raw = data.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: raw)) as? [String: Any]
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
@@ -106,6 +106,32 @@ final class SSEControllerTests: XCTestCase {
         XCTAssertEqual(spy.syncRequestedCount, 1)
     }
 
+    func test_sync_blockedByInFlightEvenAfterDebounceWindow() {
+        let spy = Spy()
+        var heldCompletion: (() -> Void)?
+        let controller = SSEController(
+            sseClient: makeDummySSEClient(),
+            onSyncRequested: { completion in
+                spy.recordSync()
+                heldCompletion = completion
+            },
+            onServerEventTriggered: { _, _ in },
+            syncDebounceInterval: 1.0,
+            scheduler: { delay, work in spy.scheduleTask(delay, work) }
+        )
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+
+        spy.flushScheduled()
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+
+        heldCompletion?()
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 2)
+    }
+
     func test_sync_afterDebounceWindow_triggersAgain() {
         let spy = Spy()
         let controller = makeController(spy: spy)

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
@@ -1,0 +1,226 @@
+//
+//  SSEControllerTests.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEControllerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private final class Spy: @unchecked Sendable {
+        let lock = NSLock()
+        private var _syncRequestedCount = 0
+        private var _eventCalls: [(String, [String: Any]?)] = []
+        private var _scheduledTasks: [(TimeInterval, () -> Void)] = []
+
+        var syncRequestedCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _syncRequestedCount
+        }
+        var eventCalls: [(String, [String: Any]?)] {
+            lock.lock(); defer { lock.unlock() }
+            return _eventCalls
+        }
+
+        func recordSync() {
+            lock.lock(); defer { lock.unlock() }
+            _syncRequestedCount += 1
+        }
+        func recordEvent(_ name: String, _ params: [String: Any]?) {
+            lock.lock(); defer { lock.unlock() }
+            _eventCalls.append((name, params))
+        }
+        func scheduleTask(_ delay: TimeInterval, _ work: @escaping () -> Void) {
+            lock.lock()
+            _scheduledTasks.append((delay, work))
+            lock.unlock()
+        }
+        /// 디바운스 윈도우 만료를 흉내내기 위해 즉시 실행.
+        func flushScheduled() {
+            lock.lock()
+            let tasks = _scheduledTasks
+            _scheduledTasks.removeAll()
+            lock.unlock()
+            for (_, work) in tasks { work() }
+        }
+    }
+
+    private func makeDummySSEClient() -> SSEClient {
+        // streamLineProvider 는 connect() 호출 시에만 발동.
+        // 본 테스트는 connect() 를 호출하지 않으므로 throw stub 으로 둔다.
+        return SSEClient(
+            projectId: "00000000000000000000000000000abc",
+            notiflyUserId: "u",
+            deviceId: nil,
+            tokenProvider: { "t" },
+            baseURLString: "https://test.local/streams",
+            streamLineProvider: { _ in
+                throw NSError(domain: "should-not-be-called", code: 0)
+            }
+        )
+    }
+
+    private func makeController(
+        spy: Spy,
+        debounce: TimeInterval = 1.0
+    ) -> SSEController {
+        let client = makeDummySSEClient()
+        return SSEController(
+            sseClient: client,
+            onSyncRequested: { completion in
+                spy.recordSync()
+                completion()
+            },
+            onServerEventTriggered: { name, params in
+                spy.recordEvent(name, params)
+            },
+            syncDebounceInterval: debounce,
+            scheduler: { delay, work in
+                spy.scheduleTask(delay, work)
+            }
+        )
+    }
+
+    // MARK: - sync routing + 디바운스
+
+    func test_sync_singleMessage_triggersSyncOnce() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+    }
+
+    func test_sync_burstWithinDebounce_triggersSyncOnce() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "sync", data: "{}")
+        controller.handleMessage(type: "sync", data: "{}")
+        controller.handleMessage(type: "sync", data: "{}")
+
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+    }
+
+    func test_sync_afterDebounceWindow_triggersAgain() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+
+        spy.flushScheduled()
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 2)
+    }
+
+    // MARK: - server-event routing
+
+    func test_serverEvent_routesNameAndParams() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(
+            type: "server-event",
+            data: "{\"name\":\"order\",\"eventParams\":{\"price\":1000}}"
+        )
+
+        XCTAssertEqual(spy.eventCalls.count, 1)
+        XCTAssertEqual(spy.eventCalls.first?.0, "order")
+        XCTAssertEqual((spy.eventCalls.first?.1?["price"] as? NSNumber)?.intValue, 1000)
+    }
+
+    func test_serverEvent_malformed_doesNotTrigger() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "server-event", data: "not json")
+        XCTAssertEqual(spy.eventCalls.count, 0)
+    }
+
+    // MARK: - unknown / connected
+
+    func test_unknownType_isIgnored() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "weird", data: "")
+        XCTAssertEqual(spy.syncRequestedCount, 0)
+        XCTAssertEqual(spy.eventCalls.count, 0)
+    }
+
+    func test_connected_exitsFallbackAndMarksOpen() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 3))
+        XCTAssertEqual(controller.mode, .fallback)
+
+        // connected 메시지가 .sse 복귀 + hasReachedOpen 셋팅을 둘 다 한다.
+        controller.handleMessage(type: "connected", data: "{}")
+        XCTAssertEqual(controller.mode, .sse)
+
+        controller.handleStateChange(.reconnecting(attempt: 10))
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    // MARK: - Fallback 진입 / 비진입
+
+    func test_reconnecting_attempt3_withoutPriorOpen_entersFallback() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 1))
+        controller.handleStateChange(.reconnecting(attempt: 2))
+        controller.handleStateChange(.reconnecting(attempt: 3))
+
+        XCTAssertEqual(controller.mode, .fallback)
+    }
+
+    func test_reconnecting_below3_doesNotEnterFallback() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 1))
+        controller.handleStateChange(.reconnecting(attempt: 2))
+
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    func test_openReachedThenManyReconnects_doesNotEnterFallback() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.open)
+        controller.handleStateChange(.reconnecting(attempt: 5))
+        controller.handleStateChange(.reconnecting(attempt: 10))
+
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    func test_connectedMessage_marksOpenSoFallbackBlocked() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "connected", data: "{}")
+        controller.handleStateChange(.reconnecting(attempt: 5))
+
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    func test_fallbackEntered_thenOpenReached_returnsToSseMode() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 3))
+        XCTAssertEqual(controller.mode, .fallback)
+
+        controller.handleStateChange(.open)
+        XCTAssertEqual(controller.mode, .sse)
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
@@ -106,6 +106,29 @@ final class SSEControllerTests: XCTestCase {
         XCTAssertEqual(spy.syncRequestedCount, 1)
     }
 
+    func test_shutdown_scheduledReconnectSkipsAfterStop() {
+        let spy = Spy()
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+        let client = makeSSEClient(provider: pb.makeProvider())
+        let controller = SSEController(
+            sseClient: client,
+            onSyncRequested: { completion in
+                spy.recordSync()
+                completion()
+            },
+            onServerEventTriggered: { _, _ in },
+            scheduler: { delay, work in spy.scheduleTask(delay, work) }
+        )
+
+        controller.handleMessage(type: "shutdown", data: "{\"reconnectInMs\":2000}")
+        controller.stop()
+        spy.flushScheduled()
+
+        // controller.stop() 후 scheduled fire 시 새 connect 시도가 일어나지 않아야 한다.
+        XCTAssertEqual(pb.capturedRequestCount, 0)
+    }
+
     func test_sync_blockedByInFlightEvenAfterDebounceWindow() {
         let spy = Spy()
         var heldCompletion: (() -> Void)?

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEMessageTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEMessageTests.swift
@@ -1,0 +1,116 @@
+//
+//  SSEMessageTests.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+final class SSEMessageTests: XCTestCase {
+
+    // MARK: - simple types
+
+    func test_connected_dataIgnored() {
+        if case .connected = SSEMessage.decode(type: "connected", data: "{\"projectId\":\"x\"}") {
+            return
+        }
+        XCTFail("expected .connected")
+    }
+
+    func test_sync_dataIgnored() {
+        if case .sync = SSEMessage.decode(type: "sync", data: "{\"ts\":1}") {
+            return
+        }
+        XCTFail("expected .sync")
+    }
+
+    func test_ttlExpired() {
+        if case .ttlExpired = SSEMessage.decode(type: "ttl-expired", data: "{\"reason\":\"connection-ttl\"}") {
+            return
+        }
+        XCTFail("expected .ttlExpired")
+    }
+
+    func test_unknown_type() {
+        if case .unknown(let raw) = SSEMessage.decode(type: "weird", data: "") {
+            XCTAssertEqual(raw, "weird")
+        } else {
+            XCTFail("expected .unknown")
+        }
+    }
+
+    // MARK: - server-event
+
+    func test_serverEvent_withNameAndEventParams() {
+        let data = "{\"name\":\"order_completed\",\"eventParams\":{\"price\":1000}}"
+        if case .event(let name, let params) = SSEMessage.decode(type: "server-event", data: data) {
+            XCTAssertEqual(name, "order_completed")
+            XCTAssertEqual(params?["price"] as? Int, 1000)
+        } else {
+            XCTFail("expected .event")
+        }
+    }
+
+    func test_serverEvent_withoutEventParams() {
+        let data = "{\"name\":\"x\"}"
+        if case .event(let name, let params) = SSEMessage.decode(type: "server-event", data: data) {
+            XCTAssertEqual(name, "x")
+            XCTAssertNil(params)
+        } else {
+            XCTFail("expected .event")
+        }
+    }
+
+    func test_serverEvent_missingName_isMalformed() {
+        let data = "{\"eventParams\":{}}"
+        if case .malformed(let raw) = SSEMessage.decode(type: "server-event", data: data) {
+            XCTAssertEqual(raw, "server-event")
+        } else {
+            XCTFail("expected .malformed")
+        }
+    }
+
+    func test_serverEvent_invalidJSON_isMalformed() {
+        if case .malformed = SSEMessage.decode(type: "server-event", data: "not json") {
+            return
+        }
+        XCTFail("expected .malformed")
+    }
+
+    // MARK: - shutdown
+
+    func test_shutdown_withReconnectInMs() {
+        let data = "{\"reason\":\"deployment\",\"reconnectInMs\":1500}"
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: data) {
+            XCTAssertEqual(ms, 1500)
+        } else {
+            XCTFail("expected .shutdown(1500)")
+        }
+    }
+
+    func test_shutdown_withoutReconnectInMs_defaultsToZero() {
+        let data = "{\"reason\":\"x\"}"
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: data) {
+            XCTAssertEqual(ms, 0)
+        } else {
+            XCTFail("expected .shutdown(0)")
+        }
+    }
+
+    func test_shutdown_invalidJSON_defaultsToZero() {
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: "garbage") {
+            XCTAssertEqual(ms, 0)
+        } else {
+            XCTFail("expected .shutdown(0)")
+        }
+    }
+
+    func test_shutdown_negativeReconnectInMs_clampedToZero() {
+        let data = "{\"reconnectInMs\":-100}"
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: data) {
+            XCTAssertEqual(ms, 0)
+        } else {
+            XCTFail("expected .shutdown(0)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

NOTIFLY-837. SSEClient (NOTIFLY-835) 위에 메시지 라우팅, sync 디바운스, Fallback 모드를 추가.

- `SSEMessage` — wire (type, data) → 의미론 메시지 디코더 (sync / server-event / shutdown / ttl-expired / connected / unknown / malformed)
- `SSEController` — SSEClient 래핑, 메시지 분기, sync 1초 leading-edge 디바운스, Fallback 모드 전이
- `UserStateManager.syncState` — `isSyncing` 가드 + nested syncState race 방지

## 동작 요약

| 메시지 | 처리 |
|---|---|
| `connected` | mode → `.sse`, `_hasReachedOpen` 셋팅 |
| `sync` | 1초 leading-edge 디바운스 후 `onSyncRequested` (→ UserStateManager.syncState) |
| `server-event` | `onServerEventTriggered(name, eventParams)` (→ InAppMessageManager.mayTriggerInAppMessage) |
| `shutdown(reconnectInMs)` | sseClient.disconnect → ms 후 connect (협력 재연결, 백오프 카운터 리셋 효과) |
| `ttl-expired` | sseClient 즉시 disconnect+connect |
| `unknown` / `malformed` | 로그만 |

### Fallback 모드

- `.open` 한 번도 도달 못한 상태에서 `attempt >= 3` → `mode = .fallback` 으로 진입, sseClient 정지
- `.open` 한 번이라도 도달했으면 끊겼다 재연결돼도 fallback 진입 X (정상 환경의 일시 장애로 간주)
- `connected` 메시지 또는 `.open` state 전이 시 `_hasReachedOpen = true` + `mode = .sse` 복귀

### isSyncing 가드

- `UserStateManager.syncState` 호출 시 in-flight 면 skip + 로깅
- `mismatchHandled` flag 로 nested syncState (external user id 불일치 분기) 가 outer receiveCompletion 의 clearInFlight 와 race 하지 않도록 차단

## 테스트

- `SSEMessageTests` — 11 cases (모든 type 디코딩, malformed, missing field, NSNumber/Int/Double reconnectInMs, negative clamp 등)
- `SSEControllerTests` — 13 cases (sync 디바운스, server-event 라우팅, fallback 진입/비진입, connected 의 fallback 탈출, malformed event 무시 등)
- 회귀 없음 — 기존 50 + 신규 24 = **74/74 통과**

## Test plan

- [x] 단위 테스트 74/74 (xcodebuild test, iPhone 17 Simulator latest)
- [x] SwiftLint error 0
- [x] App Extension 격리 (`@available(iOSApplicationExtension, unavailable)`)
- [x] CodeRabbit 사전 review 3 cycles (NSNumber reconnectInMs / nested syncState race / vacuous test → 모두 fix)
- [ ] 실서버 (stage / prod) 통합 검증 — 후속 라이프사이클 티켓에서 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Server-Sent Events(SSE) 지원 추가로 실시간 메시지 수신 기능 구현
  * SSE 연결/재연결, 폴백 모드 전환 및 TTL/종료 이벤트 처리로 안정성 향상
  * 동기화 요청 디바운스 및 서버 이벤트 라우팅 기능 추가

* **Tests**
  * SSE 메시지 디코딩 및 다양한 케이스(연결, sync, 서버이벤트, shutdown, ttl) 검증 테스트 추가
  * 컨트롤러 상태 전환, 재연결/폴백 동작 및 동기화 동작 검증 테스트 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->