### PR TITLE
feat: SSE 라이프사이클 옵저버 + byte splitter 검증 보강 (NOTIFLY-836)

### DIFF
--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8088603A8294AD238004B695 /* SSEClientTests.swift */; };
 		2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */; };
 		2BA67CD02C353D6C00240C17 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */; };
+		446EFABE891D933D8731EAC9 /* Notifly+SSE.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1A7FCDEED01E7D5936DE1 /* Notifly+SSE.swift */; };
 		4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */; };
 		672E7DF329EFA50400B3E9F2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 672E7DF229EFA50400B3E9F2 /* FirebaseMessaging */; };
 		673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */; };
@@ -94,6 +95,7 @@
 		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
 		AA00000000000011 /* NotiflyLinkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelperTests.swift; sourceTree = "<group>"; };
 		B0521E412C1B572100D4E357 /* Timezone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timezone.swift; sourceTree = "<group>"; };
+		C6C1A7FCDEED01E7D5936DE1 /* Notifly+SSE.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Notifly+SSE.swift"; sourceTree = "<group>"; };
 		F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyError.swift; sourceTree = "<group>"; };
 		F2E6696F2ADE5F7E00DF9CA0 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 				F2E669772ADE5FD000DF9CA0 /* Notifly.swift */,
 				673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */,
 				F2E669A42ADE633400DF9CA0 /* Notifly+Helper.swift */,
+				C6C1A7FCDEED01E7D5936DE1 /* Notifly+SSE.swift */,
 			);
 			path = Notifly;
 			sourceTree = "<group>";
@@ -492,6 +495,7 @@
 				AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */,
 				CE59D0CEAFC4E9DFE98E831B /* SSEMessage.swift in Sources */,
 				AB9D9076100F90E306A0CAE0 /* SSEController.swift in Sources */,
+				446EFABE891D933D8731EAC9 /* Notifly+SSE.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		10A6432EEA64DAA79DEE3CEE /* SSELineParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC56C102B6001B31A226813 /* SSELineParserTests.swift */; };
 		1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8088603A8294AD238004B695 /* SSEClientTests.swift */; };
+		E4AA3EB7E4B248B587DD5FA8 /* SSEByteLineSplitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7881ACB16354E06A9A02640 /* SSEByteLineSplitterTests.swift */; };
 		2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */; };
 		2BA67CD02C353D6C00240C17 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */; };
 		446EFABE891D933D8731EAC9 /* Notifly+SSE.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1A7FCDEED01E7D5936DE1 /* Notifly+SSE.swift */; };
@@ -76,6 +77,7 @@
 		2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncWorker.swift; sourceTree = "<group>"; };
 		2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		2CC56C102B6001B31A226813 /* SSELineParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParserTests.swift; sourceTree = "<group>"; };
+		C7881ACB16354E06A9A02640 /* SSEByteLineSplitterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEByteLineSplitterTests.swift; sourceTree = "<group>"; };
 		2DB7ADB011179147141734D5 /* SSEController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEController.swift; sourceTree = "<group>"; };
 		4DF8FB665159427B654E3954 /* SSEClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClient.swift; sourceTree = "<group>"; };
 		58EB4E2A48E97C9719C16565 /* SSELineParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParser.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */,
 				791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */,
 				69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */,
+				C7881ACB16354E06A9A02640 /* SSEByteLineSplitterTests.swift */,
 			);
 			name = SSE;
 			path = SSE;
@@ -511,6 +514,7 @@
 				D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */,
 				A86C7442166A9C64FEC1DDB7 /* SSEMessageTests.swift in Sources */,
 				E8D7CCFF63B1227A9060F876 /* SSEControllerTests.swift in Sources */,
+				E4AA3EB7E4B248B587DD5FA8 /* SSEByteLineSplitterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
@@ -40,11 +40,14 @@ final class SSEClient: @unchecked Sendable {
     static let openStableThreshold: TimeInterval = 30
 
     static func makeDefaultSession() -> URLSession {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 5
-        // 서버 Connection TTL 30분(±10%) 보다 긴 35분.
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = defaultHeartbeatTimeout
         config.timeoutIntervalForResource = 35 * 60
         config.waitsForConnectivity = false
+        config.httpMaximumConnectionsPerHost = 1
+        config.httpShouldUsePipelining = false
+        config.urlCache = nil
+        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         return URLSession(configuration: config)
     }
 
@@ -128,20 +131,40 @@ final class SSEClient: @unchecked Sendable {
             guard let http = response as? HTTPURLResponse else {
                 throw ConnectionError.invalidResponse
             }
-            let stream = AsyncThrowingStream<String, Error> { continuation in
-                let task = Task {
-                    do {
-                        for try await line in bytes.lines {
-                            continuation.yield(line)
+            return (http, splitSSELines(bytes))
+        }
+    }
+
+    internal static func splitSSELines<S: AsyncSequence>(_ bytes: S) -> AsyncThrowingStream<String, Error>
+    where S.Element == UInt8 {
+        AsyncThrowingStream<String, Error> { continuation in
+            let task = Task {
+                do {
+                    var buffer: [UInt8] = []
+                    var prevWasCR = false
+                    for try await byte in bytes {
+                        if byte == 0x0A {
+                            if prevWasCR {
+                                prevWasCR = false
+                                continue
+                            }
+                            continuation.yield(String(decoding: buffer, as: UTF8.self))
+                            buffer.removeAll(keepingCapacity: true)
+                        } else if byte == 0x0D {
+                            continuation.yield(String(decoding: buffer, as: UTF8.self))
+                            buffer.removeAll(keepingCapacity: true)
+                            prevWasCR = true
+                        } else {
+                            prevWasCR = false
+                            buffer.append(byte)
                         }
-                        continuation.finish()
-                    } catch {
-                        continuation.finish(throwing: error)
                     }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
                 }
-                continuation.onTermination = { _ in task.cancel() }
             }
-            return (http, stream)
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 
@@ -374,13 +397,13 @@ final class SSEClient: @unchecked Sendable {
         components.scheme = baseURL.scheme
         components.host = baseURL.host
         components.port = baseURL.port
-        // path component reserved/non-ASCII 대비 percent-encode.
-        let encodedProjectId = projectId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? projectId
-        let encodedUserId = notiflyUserId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? notiflyUserId
-        // baseURL.path 의 trailing slash 로 인한 // double slash 방지.
+        var pathSegmentAllowed = CharacterSet.urlPathAllowed
+        pathSegmentAllowed.remove(charactersIn: "/")
+        let encodedProjectId = projectId.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) ?? projectId
+        let encodedUserId = notiflyUserId.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) ?? notiflyUserId
         let normalizedBasePath = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         let prefix = normalizedBasePath.isEmpty ? "" : "/\(normalizedBasePath)"
-        components.path = "\(prefix)/\(encodedProjectId)/\(encodedUserId)"
+        components.path = "\(prefix)/projects/\(encodedProjectId)/users/\(encodedUserId)/streams"
         if let device = deviceId, !device.isEmpty {
             components.queryItems = [URLQueryItem(name: "deviceId", value: device)]
         }
@@ -390,7 +413,9 @@ final class SSEClient: @unchecked Sendable {
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
+        request.networkServiceType = .responsiveData
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(NotiflySdkConfig.sdkVersion, forHTTPHeaderField: "x-notifly-sdk-version")
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
 
         let last: String? = stateAccessQueue.sync { _lastEventId }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -72,8 +72,11 @@ import UIKit
             finishTask()
         }
 
-        main.registerSSELifecycleObservers()
-        main.startSSE()
+        Notifly.asyncWorker.addTask { finishTask in
+            main.registerSSELifecycleObservers()
+            main.startSSE()
+            finishTask()
+        }
     }
 
     static func application(

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -71,6 +71,9 @@ import UIKit
             Logger.info("📡 Notifly SDK is successfully initialized.")
             finishTask()
         }
+
+        main.registerSSELifecycleObservers()
+        main.startSSE()
     }
 
     static func application(
@@ -192,6 +195,7 @@ import UIKit
             return
         }
         main.userManager.setExternalUserId(userId)
+        main.restartSSE()
     }
 
     static func getNotiflyUserId() -> String? {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -198,7 +198,10 @@ import UIKit
             return
         }
         main.userManager.setExternalUserId(userId)
-        main.restartSSE()
+        Notifly.asyncWorker.addTask { finishTask in
+            main.restartSSE()
+            finishTask()
+        }
     }
 
     static func getNotiflyUserId() -> String? {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
@@ -27,10 +27,7 @@ extension Notifly {
             deviceId: deviceId,
             tokenProvider: { [weak auth] in
                 guard let auth = auth else { throw NotiflyError.notInitialized }
-                for try await token in auth.authorizationPub.first().values {
-                    return token
-                }
-                throw NotiflyError.notAuthorized
+                return try await Notifly.fetchAuthorizationToken(auth: auth)
             }
         )
 
@@ -56,13 +53,20 @@ extension Notifly {
             }
         )
 
-        sseController?.stop()
-        sseController = controller
+        sseAccessQueue.sync {
+            _sseController?.stop()
+            _sseController = controller
+        }
         controller.start()
     }
 
     func stopSSE() {
-        sseController?.stop()
+        let previous: SSEController? = sseAccessQueue.sync {
+            let c = _sseController
+            _sseController = nil
+            return c
+        }
+        previous?.stop()
     }
 
     func restartSSE() {
@@ -70,20 +74,63 @@ extension Notifly {
     }
 
     func registerSSELifecycleObservers() {
+        let shouldRegister: Bool = sseAccessQueue.sync {
+            if _sseObserversRegistered { return false }
+            _sseObserversRegistered = true
+            return true
+        }
+        guard shouldRegister else { return }
+
         let center = NotificationCenter.default
-        center.addObserver(
+        let bgToken = center.addObserver(
             forName: UIApplication.didEnterBackgroundNotification,
             object: nil,
             queue: nil
         ) { [weak self] _ in
             self?.stopSSE()
         }
-        center.addObserver(
+        let fgToken = center.addObserver(
             forName: UIApplication.willEnterForegroundNotification,
             object: nil,
             queue: nil
         ) { [weak self] _ in
             self?.startSSE()
+        }
+        sseAccessQueue.sync {
+            _sseLifecycleObserverTokens = [bgToken, fgToken]
+        }
+    }
+
+    func unregisterSSELifecycleObservers() {
+        let tokens: [NSObjectProtocol] = sseAccessQueue.sync {
+            let t = _sseLifecycleObserverTokens
+            _sseLifecycleObserverTokens = []
+            _sseObserversRegistered = false
+            return t
+        }
+        let center = NotificationCenter.default
+        for token in tokens {
+            center.removeObserver(token)
+        }
+    }
+
+    private static func fetchAuthorizationToken(auth: Auth) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                for try await token in auth.authorizationPub.first().values {
+                    return token
+                }
+                throw NotiflyError.notAuthorized
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 10_000_000_000)
+                throw NotiflyError.notAuthorized
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next() else {
+                throw NotiflyError.notAuthorized
+            }
+            return first
         }
     }
 }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
@@ -1,0 +1,89 @@
+//
+//  Notifly+SSE.swift
+//  notifly-ios-sdk
+//
+
+import Combine
+import Foundation
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+extension Notifly {
+
+    func startSSE() {
+        guard !Notifly.inAppMessageDisabled else { return }
+        guard let notiflyUserId = try? userManager.getNotiflyUserID() else {
+            Logger.info("SSE: skip start — no notifly user id yet")
+            return
+        }
+        let deviceId = AppHelper.getNotiflyDeviceID()
+        let auth = self.auth
+        let userStateManager = inAppMessageManager.userStateManager
+        let inAppMgr = inAppMessageManager
+
+        let client = SSEClient(
+            projectId: projectId,
+            notiflyUserId: notiflyUserId,
+            deviceId: deviceId,
+            tokenProvider: { [weak auth] in
+                guard let auth = auth else { throw NotiflyError.notInitialized }
+                for try await token in auth.authorizationPub.first().values {
+                    return token
+                }
+                throw NotiflyError.notAuthorized
+            }
+        )
+
+        let controller = SSEController(
+            sseClient: client,
+            onSyncRequested: { [weak userStateManager] completion in
+                guard let mgr = userStateManager else {
+                    completion()
+                    return
+                }
+                mgr.syncState(
+                    postProcessConfig: PostProcessConfigForSyncState(merge: true, clear: false)
+                ) {
+                    completion()
+                }
+            },
+            onServerEventTriggered: { [weak inAppMgr] name, params in
+                inAppMgr?.mayTriggerInAppMessage(
+                    eventName: name,
+                    eventParams: params,
+                    segmentationEventParamKeys: nil
+                )
+            }
+        )
+
+        sseController?.stop()
+        sseController = controller
+        controller.start()
+    }
+
+    func stopSSE() {
+        sseController?.stop()
+    }
+
+    func restartSSE() {
+        startSSE()
+    }
+
+    func registerSSELifecycleObservers() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.stopSSE()
+        }
+        center.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.startSSE()
+        }
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
@@ -56,8 +56,8 @@ extension Notifly {
         sseAccessQueue.sync {
             _sseController?.stop()
             _sseController = controller
+            controller.start()
         }
-        controller.start()
     }
 
     func stopSSE() {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
@@ -33,7 +33,11 @@ import UIKit
     let trackingManager: TrackingManager
     let userManager: UserManager
     let inAppMessageManager: InAppMessageManager
-    var sseController: SSEController?
+
+    let sseAccessQueue = DispatchQueue(label: "com.notifly.sse.access.queue")
+    var _sseController: SSEController?
+    var _sseLifecycleObserverTokens: [NSObjectProtocol] = []
+    var _sseObserversRegistered: Bool = false
 
     // MARK: Lifecycle
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
@@ -33,6 +33,7 @@ import UIKit
     let trackingManager: TrackingManager
     let userManager: UserManager
     let inAppMessageManager: InAppMessageManager
+    var sseController: SSEController?
 
     // MARK: Lifecycle
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -15,7 +15,7 @@ enum NotiflyConstant {
             "https://e.notifly.tech/records"
         static let syncStateEndPoint = "https://api.notifly.tech/user-state"
         static let authorizationEndPoint = "https://api.notifly.tech/authorize"
-        static let streamEndPoint = "https://api.notifly.tech/streams"
+        static let streamEndPoint = "https://api.notifly.tech"
     }
 }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEByteLineSplitterTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEByteLineSplitterTests.swift
@@ -1,0 +1,171 @@
+//
+//  SSEByteLineSplitterTests.swift
+//  notifly-ios-sdkTests
+//
+//  WHATWG SSE spec 의 line-splitting (LF / CR / CRLF) + 빈 라인 yield 검증.
+//  LaunchDarkly swift-eventsource 의 UTF8LineParserTests 케이스를 미러링.
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEByteLineSplitterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func split(_ bytes: [UInt8]) async throws -> [String] {
+        let source = AsyncStream<UInt8> { continuation in
+            for b in bytes { continuation.yield(b) }
+            continuation.finish()
+        }
+        var lines: [String] = []
+        for try await line in SSEClient.splitSSELines(source) {
+            lines.append(line)
+        }
+        return lines
+    }
+
+    private func split(_ s: String) async throws -> [String] {
+        try await split(Array(s.utf8))
+    }
+
+    // MARK: - 기본 terminator
+
+    func test_lfOnly_yieldsSingleEmptyLine() async throws {
+        let out = try await split("\n")
+        XCTAssertEqual(out, [""])
+    }
+
+    func test_crOnly_yieldsSingleEmptyLine() async throws {
+        let out = try await split("\r")
+        XCTAssertEqual(out, [""])
+    }
+
+    func test_crlf_yieldsSingleEmptyLine() async throws {
+        let out = try await split("\r\n")
+        XCTAssertEqual(out, [""])
+    }
+
+    func test_singleLine_lf() async throws {
+        let out = try await split("hello\n")
+        XCTAssertEqual(out, ["hello"])
+    }
+
+    func test_singleLine_cr() async throws {
+        let out = try await split("hello\r")
+        XCTAssertEqual(out, ["hello"])
+    }
+
+    func test_singleLine_crlf() async throws {
+        let out = try await split("hello\r\n")
+        XCTAssertEqual(out, ["hello"])
+    }
+
+    // MARK: - EOF discard (WHATWG: pending data must be discarded)
+
+    func test_unterminatedTail_isDiscarded() async throws {
+        let out = try await split("hello")
+        XCTAssertEqual(out, [])
+    }
+
+    func test_terminatedThenUnterminated_yieldsOnlyTerminated() async throws {
+        let out = try await split("a\nbcd")
+        XCTAssertEqual(out, ["a"])
+    }
+
+    // MARK: - mixed line endings
+
+    func test_mixedLineEndings_inSingleStream() async throws {
+        let out = try await split("a\nb\r\nc\rd\n")
+        XCTAssertEqual(out, ["a", "b", "c", "d"])
+    }
+
+    // MARK: - 연속 blank line — SSE event terminator 핵심 케이스
+
+    func test_consecutiveLF_yieldsMultipleBlankLines() async throws {
+        let out = try await split("\n\n\n")
+        XCTAssertEqual(out, ["", "", ""])
+    }
+
+    func test_consecutiveCRLF_yieldsMultipleBlankLines() async throws {
+        let out = try await split("\r\n\r\n")
+        XCTAssertEqual(out, ["", ""])
+    }
+
+    func test_blankLineBetweenContent() async throws {
+        let out = try await split("a\n\nb\n")
+        XCTAssertEqual(out, ["a", "", "b"])
+    }
+
+    func test_sseEventBlock_endsWithBlankLine() async throws {
+        // 우리가 고치는 핵심 시나리오 — server 가 보낸 event terminator 가 SDK 까지 보존.
+        let out = try await split("event: sync\ndata: {}\n\n")
+        XCTAssertEqual(out, ["event: sync", "data: {}", ""])
+    }
+
+    // MARK: - CR 직후 비-LF byte
+
+    func test_crFollowedByText_treatsCRAsTerminator() async throws {
+        // \r 직후 text → \r 이 line terminator 로 작동, 'b' 는 다음 라인 시작
+        let out = try await split("a\rb\n")
+        XCTAssertEqual(out, ["a", "b"])
+    }
+
+    func test_crFollowedByCR_eachIsTerminator() async throws {
+        let out = try await split("a\r\rb\n")
+        XCTAssertEqual(out, ["a", "", "b"])
+    }
+
+    func test_lfFollowedByCR_eachIsTerminator() async throws {
+        // \n 다음 \r — prevWasCR 가 set 되지 않은 상태라 \r 가 독립적 terminator
+        let out = try await split("a\n\rb\n")
+        XCTAssertEqual(out, ["a", "", "b"])
+    }
+
+    // MARK: - unicode 보존
+
+    func test_unicodeContent_preserved() async throws {
+        let out = try await split("안녕하세요\n")
+        XCTAssertEqual(out, ["안녕하세요"])
+    }
+
+    func test_emojiContent_preserved() async throws {
+        let out = try await split("hi 🚀\n")
+        XCTAssertEqual(out, ["hi 🚀"])
+    }
+
+    func test_diacritics_preserved() async throws {
+        let out = try await split("café\n")
+        XCTAssertEqual(out, ["café"])
+    }
+
+    // MARK: - 통합 SSE 시나리오 — server 가 실제 보내는 형태
+
+    func test_realisticSSEEventStream() async throws {
+        // 두 개의 event block (connected, sync) + heartbeat comment.
+        // 각 블록은 blank line 으로 종료된다. (Swift multiline literal 은 closing """ 직전의
+        // 줄바꿈을 자동 제거하므로 마지막 terminator 는 명시적으로 \n 추가한다.)
+        let stream = "event: connected\n"
+            + "data: {\"projectId\":\"abc\"}\n"
+            + "\n"
+            + "id: 42\n"
+            + "event: sync\n"
+            + "data: {}\n"
+            + "\n"
+            + ": heartbeat\n"
+            + "\n"
+        let out = try await split(stream)
+        XCTAssertEqual(out, [
+            "event: connected",
+            "data: {\"projectId\":\"abc\"}",
+            "",
+            "id: 42",
+            "event: sync",
+            "data: {}",
+            "",
+            ": heartbeat",
+            "",
+        ])
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
@@ -142,7 +142,7 @@ extension XCTestCase {
             notiflyUserId: "user-42",
             deviceId: deviceId,
             tokenProvider: token,
-            baseURLString: "https://test.local/streams",
+            baseURLString: "https://test.local",
             backoffSchedule: backoff,
             heartbeatTimeout: heartbeatTimeout,
             streamLineProvider: provider,

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
@@ -83,7 +83,7 @@ final class SSEClientTests: XCTestCase {
         XCTAssertEqual(captured?.value(forHTTPHeaderField: "Authorization"), "Bearer my-token")
         XCTAssertEqual(captured?.value(forHTTPHeaderField: "Accept"), "text/event-stream")
         XCTAssertNil(captured?.value(forHTTPHeaderField: "Last-Event-ID"))
-        XCTAssertEqual(captured?.url?.path, "/streams/00000000000000000000000000000abc/user-42")
+        XCTAssertEqual(captured?.url?.path, "/projects/00000000000000000000000000000abc/users/user-42/streams")
         XCTAssertEqual(captured?.url?.query, "deviceId=device-1")
 
         client.disconnect()

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
@@ -57,7 +57,7 @@ final class SSEControllerTests: XCTestCase {
             notiflyUserId: "u",
             deviceId: nil,
             tokenProvider: { "t" },
-            baseURLString: "https://test.local/streams",
+            baseURLString: "https://test.local",
             streamLineProvider: { _ in
                 throw NSError(domain: "should-not-be-called", code: 0)
             }


### PR DESCRIPTION
## Summary

- `UIApplication.didEnterBackground` / `willEnterForeground` 옵저버 + `sseAccessQueue` 로 SSE 라이프사이클 제어.
- `URLSession.AsyncBytes.lines` 가 빈 라인을 yield 하지 않아 SSE event terminator (blank line) 가 손실되던 문제를 byte-level `splitSSELines` 로 우회. WHATWG SSE spec 의 `\n` / `\r\n` / `\r` terminator + blank line yield + EOF discard 정합.
- SSE endpoint path 를 서버와 정합: `/streams/{p}/{u}` → `/projects/{p}/users/{u}/streams`.
- `path segment encoding` 을 stricter `CharacterSet` (urlPathAllowed 에서 `/` 제외) 으로 변경 — projectId / userId 의 path injection 방어.
- `URLSession` config 강화 — `.ephemeral`, `timeoutIntervalForRequest = heartbeatTimeout`, `timeoutIntervalForResource = 35분`, `httpMaximumConnectionsPerHost = 1`, `urlCache = nil`.
- `tokenProvider` 를 10s timeout 으로 wrap (`fetchAuthorizationToken`) — 인증 단계가 무한 hang 하지 않음.
- `registerSSELifecycleObservers` 멱등 + `unregisterSSELifecycleObservers` 추가 + observer token 보관.

## 검증

- `xcodebuild test` 통과 (SSE 전체 + 신규 `SSEByteLineSplitterTests` 20+ 케이스).
- `SSEByteLineSplitterTests` 는 LaunchDarkly `swift-eventsource` 의 `UTF8LineParserTests` 를 미러링: CR/LF/CRLF, 연속 blank line, mixed endings, EOF discard, unicode/emoji, CR-followed-by-CR 등.
- stage 환경 end-to-end 검증 끝 — broker publish → SDK 까지 sync event 도달 + `syncState` 호출 확인.
- CodeRabbit CLI 사전 review (2 cycles) 통과 — 1 valid finding (path segment encoding) fix, 2 false positive / 1 already-addressed.

## 임시 디버그 정리

검증 중 추가했던 디버그 변경을 모두 revert:
- `Logger.info("[net] ...")`, `Logger.info("[sse] line: ...")` 등 raw line / 라이프사이클 로그 전체 제거
- `Accept-Encoding: identity`, `Cache-Control: no-cache`, `User-Agent: curl/8.7.1` 등 임시 헤더 제거
- `Constants.swift` 의 stage URL → prod URL 복원
- `NotiflyAPI` / `NotiflyAPI+Request` 의 `[net] sync-state` timing 진단 코드 제거

## Test plan

- [x] `xcodebuild -scheme notifly-ios-sdkTests test` 전체 통과
- [x] CodeRabbit CLI review 2 cycles 통과
- [ ] stage 환경에서 라이프사이클 background/foreground 트랜지션 시 SSE start/stop 동작 회귀 확인
- [ ] popup-v2 머지 후 main 으로 묶을 PR 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 서버 전송 이벤트(SSE) 기반 실시간 스트리밍 시작/중지/재시작 API 및 수명주기 관찰자 추가
  * 사용자 ID 변경 시 SSE 자동 재시작

* **개선**
  * 요청 헤더에 SDK 버전 포함 및 네트워크 세션/캐시/서비스 유형 조정으로 연결 신뢰성 향상
  * URL 경로 구성 및 인코딩 로직 개선으로 올바른 엔드포인트 사용 보장
  * 기본 스트림 엔드포인트 호스트 경로 정리

* **테스트**
  * 다양한 라인 종료(CR/LF/CRLF) 및 이벤트 파싱을 검증하는 포괄적 단위/통합 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-michael/notifly-ios-sdk/pull/114)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->