### PR TITLE
feat: SSE 기반 실시간 캠페인 데이터 동기화 + 2.5.0 출시

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-06-01
+
+### Changed
+
+- Switch SSE reconnect backoff to full jitter (100ms ~ 10s) across all attempts.
+  - Previous schedule was `[1, 2, 4, 8, 30]s` with ±20% multiplicative jitter; attempt 1 spread was only ~400ms.
+  - New schedule uses a single 10s base with 0~1 uniform jitter (clamped to 100ms minimum), producing a ~9.9s window to better disperse reconnect bursts after server-side disconnects (e.g. rolling deploys).
+- Reduce SSE verbose logging. Keep: `connected`, `disconnected`, `sync received` plus error logs (`connection error`, `handshake failed`, `invalid content-type`, `malformed message`). Remove per-attempt traces, `Last-Event-ID` headers, `event received`, `shutdown received`, and lifecycle entry/exit logs.
+
 ## [2.4.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.5.0] - 2026-06-01
 
+### Added
+
+- **Real-time campaign data sync over SSE.**
+  - Open a long-lived SSE channel from the SDK to Notifly server. When campaign state changes server-side (e.g. a new in-app message is triggered or a popup is updated), the SDK refreshes its local campaign data immediately instead of waiting for the next event-driven fetch.
+  - On reconnect, the SDK sends `Last-Event-ID` so the server can replay popup entries that were missed during the disconnect window, recovering messages that fired while offline.
+  - If the SSE channel cannot reach OPEN state within the fallback threshold, the SDK falls back to the legacy event-driven sync path automatically.
+
 ### Changed
 
-- Switch SSE reconnect backoff to full jitter (100ms ~ 10s) across all attempts.
-  - Previous schedule was `[1, 2, 4, 8, 30]s` with ±20% multiplicative jitter; attempt 1 spread was only ~400ms.
-  - New schedule uses a single 10s base with 0~1 uniform jitter (clamped to 100ms minimum), producing a ~9.9s window to better disperse reconnect bursts after server-side disconnects (e.g. rolling deploys).
-- Reduce SSE verbose logging. Keep: `connected`, `disconnected`, `sync received` plus error logs (`connection error`, `handshake failed`, `invalid content-type`, `malformed message`). Remove per-attempt traces, `Last-Event-ID` headers, `event received`, `shutdown received`, and lifecycle entry/exit logs.
+- Reconnect backoff uses full jitter (100ms ~ 10s) across all attempts to disperse reconnect bursts after server-side disconnects such as rolling deploys.
+- Reduce SSE verbose logging. Keep: `SSE connected`, `SSE disconnected`, `SSE sync received` plus error logs.
 
 ## [2.4.0] - 2026-04-14
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -18,14 +18,18 @@
 		673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */; };
 		673F0EBB29EC610400814217 /* Notifly+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */; };
 		8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EB4E2A48E97C9719C16565 /* SSELineParser.swift */; };
+		A86C7442166A9C64FEC1DDB7 /* SSEMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */; };
 		AA00000000000001 /* NotiflyLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000002 /* NotiflyLinkHelper.swift */; };
 		AA00000000000003 /* ApplicationBinary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000004 /* ApplicationBinary.swift */; };
 		AA00000000000005 /* EntitlementsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000006 /* EntitlementsReader.swift */; };
 		AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000011 /* NotiflyLinkHelperTests.swift */; };
+		AB9D9076100F90E306A0CAE0 /* SSEController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB7ADB011179147141734D5 /* SSEController.swift */; };
 		AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF8FB665159427B654E3954 /* SSEClient.swift */; };
 		B0521E422C1B572100D4E357 /* Timezone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0521E412C1B572100D4E357 /* Timezone.swift */; };
 		B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */; };
+		CE59D0CEAFC4E9DFE98E831B /* SSEMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F73731CE6187DC3BD9A3F5 /* SSEMessage.swift */; };
 		D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */; };
+		E8D7CCFF63B1227A9060F876 /* SSEControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */; };
 		F2E6697B2ADE600000DF9CA0 /* NotiflyExtensionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */; };
 		F2E6697C2ADE600000DF9CA0 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */; };
 		F2E6698F2ADE602900DF9CA0 /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697F2ADE602900DF9CA0 /* NotificationsManager.swift */; };
@@ -66,10 +70,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		24F73731CE6187DC3BD9A3F5 /* SSEMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEMessage.swift; sourceTree = "<group>"; };
 		2B91499B2BDA3C3A0066CDD0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncWorker.swift; sourceTree = "<group>"; };
 		2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		2CC56C102B6001B31A226813 /* SSELineParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParserTests.swift; sourceTree = "<group>"; };
+		2DB7ADB011179147141734D5 /* SSEController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEController.swift; sourceTree = "<group>"; };
 		4DF8FB665159427B654E3954 /* SSEClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClient.swift; sourceTree = "<group>"; };
 		58EB4E2A48E97C9719C16565 /* SSELineParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParser.swift; sourceTree = "<group>"; };
 		673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = notifly_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,6 +83,8 @@
 		673F0E8A29EBA7D200814217 /* notifly-ios-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "notifly-ios-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notifly_ios_sdkTests.swift; sourceTree = "<group>"; };
 		673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notifly+PublicAPI.swift"; sourceTree = "<group>"; };
+		69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEControllerTests.swift; sourceTree = "<group>"; };
+		791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEMessageTests.swift; sourceTree = "<group>"; };
 		7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientResponseValidationTests.swift; sourceTree = "<group>"; };
 		8088603A8294AD238004B695 /* SSEClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientTests.swift; sourceTree = "<group>"; };
 		8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEEvent.swift; sourceTree = "<group>"; };
@@ -142,6 +150,8 @@
 				8088603A8294AD238004B695 /* SSEClientTests.swift */,
 				99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */,
 				7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */,
+				791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */,
+				69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */,
 			);
 			name = SSE;
 			path = SSE;
@@ -153,6 +163,8 @@
 				8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */,
 				58EB4E2A48E97C9719C16565 /* SSELineParser.swift */,
 				4DF8FB665159427B654E3954 /* SSEClient.swift */,
+				24F73731CE6187DC3BD9A3F5 /* SSEMessage.swift */,
+				2DB7ADB011179147141734D5 /* SSEController.swift */,
 			);
 			name = SSE;
 			path = SSE;
@@ -478,6 +490,8 @@
 				B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */,
 				8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */,
 				AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */,
+				CE59D0CEAFC4E9DFE98E831B /* SSEMessage.swift in Sources */,
+				AB9D9076100F90E306A0CAE0 /* SSEController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -491,6 +505,8 @@
 				1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */,
 				4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */,
 				D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */,
+				A86C7442166A9C64FEC1DDB7 /* SSEMessageTests.swift in Sources */,
+				E8D7CCFF63B1227A9060F876 /* SSEControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -7,15 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		10A6432EEA64DAA79DEE3CEE /* SSELineParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC56C102B6001B31A226813 /* SSELineParserTests.swift */; };
+		1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8088603A8294AD238004B695 /* SSEClientTests.swift */; };
 		2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */; };
 		2BA67CD02C353D6C00240C17 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */; };
+		4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */; };
 		672E7DF329EFA50400B3E9F2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 672E7DF229EFA50400B3E9F2 /* FirebaseMessaging */; };
 		673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */; };
 		673F0E8B29EBA7D200814217 /* notifly_ios_sdk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */; };
 		673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */; };
-		AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000011 /* NotiflyLinkHelperTests.swift */; };
 		673F0EBB29EC610400814217 /* Notifly+PublicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */; };
+		8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58EB4E2A48E97C9719C16565 /* SSELineParser.swift */; };
+		AA00000000000001 /* NotiflyLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000002 /* NotiflyLinkHelper.swift */; };
+		AA00000000000003 /* ApplicationBinary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000004 /* ApplicationBinary.swift */; };
+		AA00000000000005 /* EntitlementsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000006 /* EntitlementsReader.swift */; };
+		AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000011 /* NotiflyLinkHelperTests.swift */; };
+		AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF8FB665159427B654E3954 /* SSEClient.swift */; };
 		B0521E422C1B572100D4E357 /* Timezone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0521E412C1B572100D4E357 /* Timezone.swift */; };
+		B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */; };
+		D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */; };
 		F2E6697B2ADE600000DF9CA0 /* NotiflyExtensionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */; };
 		F2E6697C2ADE600000DF9CA0 /* NotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */; };
 		F2E6698F2ADE602900DF9CA0 /* NotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6697F2ADE602900DF9CA0 /* NotificationsManager.swift */; };
@@ -29,9 +39,6 @@
 		F2E669982ADE602900DF9CA0 /* TrackingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6698C2ADE602900DF9CA0 /* TrackingManager.swift */; };
 		F2E669992ADE602900DF9CA0 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6698E2ADE602900DF9CA0 /* UserManager.swift */; };
 		F2E6699A2ADE60A600DF9CA0 /* AppHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669762ADE5FD000DF9CA0 /* AppHelper.swift */; };
-		AA00000000000001 /* NotiflyLinkHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000002 /* NotiflyLinkHelper.swift */; };
-		AA00000000000003 /* ApplicationBinary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000004 /* ApplicationBinary.swift */; };
-		AA00000000000005 /* EntitlementsReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000006 /* EntitlementsReader.swift */; };
 		F2E6699B2ADE60AA00DF9CA0 /* Notifly.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E669772ADE5FD000DF9CA0 /* Notifly.swift */; };
 		F2E6699C2ADE60AD00DF9CA0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */; };
 		F2E6699D2ADE60AF00DF9CA0 /* NotiflyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */; };
@@ -62,12 +69,22 @@
 		2B91499B2BDA3C3A0066CDD0 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncWorker.swift; sourceTree = "<group>"; };
 		2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
+		2CC56C102B6001B31A226813 /* SSELineParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParserTests.swift; sourceTree = "<group>"; };
+		4DF8FB665159427B654E3954 /* SSEClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClient.swift; sourceTree = "<group>"; };
+		58EB4E2A48E97C9719C16565 /* SSELineParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParser.swift; sourceTree = "<group>"; };
 		673F0E8029EBA7D200814217 /* notifly_ios_sdk.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = notifly_ios_sdk.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = notifly_ios_sdk.docc; sourceTree = "<group>"; };
 		673F0E8A29EBA7D200814217 /* notifly-ios-sdkTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "notifly-ios-sdkTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = notifly_ios_sdkTests.swift; sourceTree = "<group>"; };
-		AA00000000000011 /* NotiflyLinkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelperTests.swift; sourceTree = "<group>"; };
 		673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notifly+PublicAPI.swift"; sourceTree = "<group>"; };
+		7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientResponseValidationTests.swift; sourceTree = "<group>"; };
+		8088603A8294AD238004B695 /* SSEClientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientTests.swift; sourceTree = "<group>"; };
+		8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEEvent.swift; sourceTree = "<group>"; };
+		99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClientTestSupport.swift; sourceTree = "<group>"; };
+		AA00000000000002 /* NotiflyLinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelper.swift; sourceTree = "<group>"; };
+		AA00000000000004 /* ApplicationBinary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBinary.swift; sourceTree = "<group>"; };
+		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
+		AA00000000000011 /* NotiflyLinkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelperTests.swift; sourceTree = "<group>"; };
 		B0521E412C1B572100D4E357 /* Timezone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timezone.swift; sourceTree = "<group>"; };
 		F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyError.swift; sourceTree = "<group>"; };
@@ -78,9 +95,6 @@
 		F2E669732ADE5F7E00DF9CA0 /* UUID+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UUID+.swift"; sourceTree = "<group>"; };
 		F2E669742ADE5F7E00DF9CA0 /* TrackingEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingEvent.swift; sourceTree = "<group>"; };
 		F2E669762ADE5FD000DF9CA0 /* AppHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHelper.swift; sourceTree = "<group>"; };
-		AA00000000000002 /* NotiflyLinkHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelper.swift; sourceTree = "<group>"; };
-		AA00000000000004 /* ApplicationBinary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBinary.swift; sourceTree = "<group>"; };
-		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
 		F2E669772ADE5FD000DF9CA0 /* Notifly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifly.swift; sourceTree = "<group>"; };
 		F2E669792ADE600000DF9CA0 /* NotiflyExtensionAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotiflyExtensionAPI.swift; sourceTree = "<group>"; };
 		F2E6697A2ADE600000DF9CA0 /* NotificationServiceExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationServiceExtension.swift; sourceTree = "<group>"; };
@@ -121,6 +135,29 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		074A991EAD22EC70CA4CFBC7 /* SSE */ = {
+			isa = PBXGroup;
+			children = (
+				2CC56C102B6001B31A226813 /* SSELineParserTests.swift */,
+				8088603A8294AD238004B695 /* SSEClientTests.swift */,
+				99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */,
+				7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */,
+			);
+			name = SSE;
+			path = SSE;
+			sourceTree = "<group>";
+		};
+		3273667AAB6C57C5AD35F0FB /* SSE */ = {
+			isa = PBXGroup;
+			children = (
+				8663B7A6BC0A5C187DC265CC /* SSEEvent.swift */,
+				58EB4E2A48E97C9719C16565 /* SSELineParser.swift */,
+				4DF8FB665159427B654E3954 /* SSEClient.swift */,
+			);
+			name = SSE;
+			path = SSE;
+			sourceTree = "<group>";
+		};
 		673F0E7629EBA7D200814217 = {
 			isa = PBXGroup;
 			children = (
@@ -155,6 +192,7 @@
 			children = (
 				673F0E8F29EBA7D200814217 /* notifly_ios_sdkTests.swift */,
 				AA00000000000011 /* NotiflyLinkHelperTests.swift */,
+				074A991EAD22EC70CA4CFBC7 /* SSE */,
 			);
 			path = "notifly-ios-sdkTests";
 			sourceTree = "<group>";
@@ -228,6 +266,7 @@
 				F2E6697E2ADE602900DF9CA0 /* Notifications */,
 				F2E6698B2ADE602900DF9CA0 /* Tracking */,
 				F2E6698D2ADE602900DF9CA0 /* User */,
+				3273667AAB6C57C5AD35F0FB /* SSE */,
 			);
 			path = Infrastructures;
 			sourceTree = "<group>";
@@ -436,6 +475,9 @@
 				F2E669902ADE602900DF9CA0 /* Auth.swift in Sources */,
 				F2E669912ADE602900DF9CA0 /* InAppMessage+Constant.swift in Sources */,
 				F2E6699C2ADE60AD00DF9CA0 /* Constants.swift in Sources */,
+				B1F29A6F46F27718F38014F4 /* SSEEvent.swift in Sources */,
+				8A43318D8B623E19A6120EEF /* SSELineParser.swift in Sources */,
+				AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -445,6 +487,10 @@
 			files = (
 				673F0E9029EBA7D200814217 /* notifly_ios_sdkTests.swift in Sources */,
 				AA00000000000010 /* NotiflyLinkHelperTests.swift in Sources */,
+				10A6432EEA64DAA79DEE3CEE /* SSELineParserTests.swift in Sources */,
+				1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */,
+				4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */,
+				D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk.xcodeproj/project.pbxproj
@@ -9,8 +9,10 @@
 /* Begin PBXBuildFile section */
 		10A6432EEA64DAA79DEE3CEE /* SSELineParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC56C102B6001B31A226813 /* SSELineParserTests.swift */; };
 		1B35C9B1103465E89B62A05C /* SSEClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8088603A8294AD238004B695 /* SSEClientTests.swift */; };
+		E4AA3EB7E4B248B587DD5FA8 /* SSEByteLineSplitterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7881ACB16354E06A9A02640 /* SSEByteLineSplitterTests.swift */; };
 		2BA089BC2C28725000BEEE8F /* AsyncWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */; };
 		2BA67CD02C353D6C00240C17 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */; };
+		446EFABE891D933D8731EAC9 /* Notifly+SSE.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C1A7FCDEED01E7D5936DE1 /* Notifly+SSE.swift */; };
 		4D4437A6DFC7EDD0358CEE97 /* SSEClientTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99830B8E91F63DCE23D278DD /* SSEClientTestSupport.swift */; };
 		672E7DF329EFA50400B3E9F2 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 672E7DF229EFA50400B3E9F2 /* FirebaseMessaging */; };
 		673F0E8529EBA7D200814217 /* notifly_ios_sdk.docc in Sources */ = {isa = PBXBuildFile; fileRef = 673F0E8429EBA7D200814217 /* notifly_ios_sdk.docc */; };
@@ -75,6 +77,7 @@
 		2BA089BB2C28725000BEEE8F /* AsyncWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncWorker.swift; sourceTree = "<group>"; };
 		2BA67CCF2C353D6C00240C17 /* AnyCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		2CC56C102B6001B31A226813 /* SSELineParserTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParserTests.swift; sourceTree = "<group>"; };
+		C7881ACB16354E06A9A02640 /* SSEByteLineSplitterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEByteLineSplitterTests.swift; sourceTree = "<group>"; };
 		2DB7ADB011179147141734D5 /* SSEController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEController.swift; sourceTree = "<group>"; };
 		4DF8FB665159427B654E3954 /* SSEClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSEClient.swift; sourceTree = "<group>"; };
 		58EB4E2A48E97C9719C16565 /* SSELineParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SSELineParser.swift; sourceTree = "<group>"; };
@@ -94,6 +97,7 @@
 		AA00000000000006 /* EntitlementsReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementsReader.swift; sourceTree = "<group>"; };
 		AA00000000000011 /* NotiflyLinkHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyLinkHelperTests.swift; sourceTree = "<group>"; };
 		B0521E412C1B572100D4E357 /* Timezone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timezone.swift; sourceTree = "<group>"; };
+		C6C1A7FCDEED01E7D5936DE1 /* Notifly+SSE.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Notifly+SSE.swift"; sourceTree = "<group>"; };
 		F2E6696D2ADE5F7E00DF9CA0 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		F2E6696E2ADE5F7E00DF9CA0 /* NotiflyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotiflyError.swift; sourceTree = "<group>"; };
 		F2E6696F2ADE5F7E00DF9CA0 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -152,6 +156,7 @@
 				7C512F3BA05105F3657B0788 /* SSEClientResponseValidationTests.swift */,
 				791AA0E993C3AF80BA96B985 /* SSEMessageTests.swift */,
 				69CADC01D5E1D922E3E1463E /* SSEControllerTests.swift */,
+				C7881ACB16354E06A9A02640 /* SSEByteLineSplitterTests.swift */,
 			);
 			name = SSE;
 			path = SSE;
@@ -256,6 +261,7 @@
 				F2E669772ADE5FD000DF9CA0 /* Notifly.swift */,
 				673F0EBA29EC610400814217 /* Notifly+PublicAPI.swift */,
 				F2E669A42ADE633400DF9CA0 /* Notifly+Helper.swift */,
+				C6C1A7FCDEED01E7D5936DE1 /* Notifly+SSE.swift */,
 			);
 			path = Notifly;
 			sourceTree = "<group>";
@@ -492,6 +498,7 @@
 				AF5757CF8D911756FE798205 /* SSEClient.swift in Sources */,
 				CE59D0CEAFC4E9DFE98E831B /* SSEMessage.swift in Sources */,
 				AB9D9076100F90E306A0CAE0 /* SSEController.swift in Sources */,
+				446EFABE891D933D8731EAC9 /* Notifly+SSE.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -507,6 +514,7 @@
 				D57A8723E4967D4B8BAA69E9 /* SSEClientResponseValidationTests.swift in Sources */,
 				A86C7442166A9C64FEC1DDB7 /* SSEMessageTests.swift in Sources */,
 				E8D7CCFF63B1227A9060F876 /* SSEControllerTests.swift in Sources */,
+				E4AA3EB7E4B248B587DD5FA8 /* SSEByteLineSplitterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
@@ -40,11 +40,14 @@ final class SSEClient: @unchecked Sendable {
     static let openStableThreshold: TimeInterval = 30
 
     static func makeDefaultSession() -> URLSession {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 5
-        // 서버 Connection TTL 30분(±10%) 보다 긴 35분.
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = defaultHeartbeatTimeout
         config.timeoutIntervalForResource = 35 * 60
         config.waitsForConnectivity = false
+        config.httpMaximumConnectionsPerHost = 1
+        config.httpShouldUsePipelining = false
+        config.urlCache = nil
+        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         return URLSession(configuration: config)
     }
 
@@ -128,20 +131,40 @@ final class SSEClient: @unchecked Sendable {
             guard let http = response as? HTTPURLResponse else {
                 throw ConnectionError.invalidResponse
             }
-            let stream = AsyncThrowingStream<String, Error> { continuation in
-                let task = Task {
-                    do {
-                        for try await line in bytes.lines {
-                            continuation.yield(line)
+            return (http, splitSSELines(bytes))
+        }
+    }
+
+    internal static func splitSSELines<S: AsyncSequence>(_ bytes: S) -> AsyncThrowingStream<String, Error>
+    where S.Element == UInt8 {
+        AsyncThrowingStream<String, Error> { continuation in
+            let task = Task {
+                do {
+                    var buffer: [UInt8] = []
+                    var prevWasCR = false
+                    for try await byte in bytes {
+                        if byte == 0x0A {
+                            if prevWasCR {
+                                prevWasCR = false
+                                continue
+                            }
+                            continuation.yield(String(decoding: buffer, as: UTF8.self))
+                            buffer.removeAll(keepingCapacity: true)
+                        } else if byte == 0x0D {
+                            continuation.yield(String(decoding: buffer, as: UTF8.self))
+                            buffer.removeAll(keepingCapacity: true)
+                            prevWasCR = true
+                        } else {
+                            prevWasCR = false
+                            buffer.append(byte)
                         }
-                        continuation.finish()
-                    } catch {
-                        continuation.finish(throwing: error)
                     }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
                 }
-                continuation.onTermination = { _ in task.cancel() }
             }
-            return (http, stream)
+            continuation.onTermination = { _ in task.cancel() }
         }
     }
 
@@ -374,13 +397,13 @@ final class SSEClient: @unchecked Sendable {
         components.scheme = baseURL.scheme
         components.host = baseURL.host
         components.port = baseURL.port
-        // path component reserved/non-ASCII 대비 percent-encode.
-        let encodedProjectId = projectId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? projectId
-        let encodedUserId = notiflyUserId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? notiflyUserId
-        // baseURL.path 의 trailing slash 로 인한 // double slash 방지.
+        var pathSegmentAllowed = CharacterSet.urlPathAllowed
+        pathSegmentAllowed.remove(charactersIn: "/")
+        let encodedProjectId = projectId.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) ?? projectId
+        let encodedUserId = notiflyUserId.addingPercentEncoding(withAllowedCharacters: pathSegmentAllowed) ?? notiflyUserId
         let normalizedBasePath = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         let prefix = normalizedBasePath.isEmpty ? "" : "/\(normalizedBasePath)"
-        components.path = "\(prefix)/\(encodedProjectId)/\(encodedUserId)"
+        components.path = "\(prefix)/projects/\(encodedProjectId)/users/\(encodedUserId)/streams"
         if let device = deviceId, !device.isEmpty {
             components.queryItems = [URLQueryItem(name: "deviceId", value: device)]
         }
@@ -390,7 +413,9 @@ final class SSEClient: @unchecked Sendable {
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
+        request.networkServiceType = .responsiveData
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(NotiflySdkConfig.sdkVersion, forHTTPHeaderField: "x-notifly-sdk-version")
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
 
         let last: String? = stateAccessQueue.sync { _lastEventId }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
@@ -34,7 +34,7 @@ final class SSEClient: @unchecked Sendable {
 
     // MARK: - Static defaults
 
-    static let defaultBackoffSchedule: [TimeInterval] = [1, 2, 4, 8, 30]
+    static let defaultBackoffSchedule: [TimeInterval] = [10]
     static let defaultHeartbeatTimeout: TimeInterval = 60
     /// .open 이 이 시간 이상 유지된 뒤 끊기면 정상 운영 상태로 간주, 백오프 attempt 카운터를 리셋한다.
     static let openStableThreshold: TimeInterval = 30
@@ -103,7 +103,7 @@ final class SSEClient: @unchecked Sendable {
         backoffSchedule: [TimeInterval] = SSEClient.defaultBackoffSchedule,
         heartbeatTimeout: TimeInterval = SSEClient.defaultHeartbeatTimeout,
         streamLineProvider: StreamLineProvider? = nil,
-        jitterProvider: @escaping () -> Double = { Double.random(in: 0.8...1.2) },
+        jitterProvider: @escaping () -> Double = { Double.random(in: 0..<1) },
         nowProvider: @escaping () -> Date = { Date() }
     ) {
         self.projectId = projectId
@@ -199,6 +199,7 @@ final class SSEClient: @unchecked Sendable {
             didStart = true
         }
         if didStart {
+            Logger.info("SSE connect requested: projectId=\(projectId) userId=\(notiflyUserId) deviceId=\(deviceId ?? "-")")
             emitState(.connecting)
         }
     }
@@ -216,6 +217,7 @@ final class SSEClient: @unchecked Sendable {
 
         connTask?.cancel()
         if !alreadyStopped {
+            Logger.info("SSE disconnect requested: projectId=\(projectId) userId=\(notiflyUserId)")
             emitState(.stopped)
         }
     }
@@ -278,14 +280,17 @@ final class SSEClient: @unchecked Sendable {
         let (http, lines) = try await streamLineProvider(request)
         // 200 외 status (204, 304 등) 는 빈 body 로 즉시 종료 → 재연결 thrashing 유발하므로 reject.
         guard http.statusCode == 200 else {
+            Logger.error("SSE handshake failed: status=\(http.statusCode) projectId=\(projectId)")
             throw ConnectionError.httpStatus(http.statusCode)
         }
         let contentType = (http.value(forHTTPHeaderField: "Content-Type") ?? "").lowercased()
         guard contentType.hasPrefix("text/event-stream") else {
+            Logger.error("SSE invalid content-type: \(contentType) projectId=\(projectId)")
             throw ConnectionError.invalidResponse
         }
 
         transition(to: .open)
+        Logger.info("SSE connected: projectId=\(projectId) userId=\(notiflyUserId) deviceId=\(deviceId ?? "-")")
         setLastDataAt(nowProvider())
 
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -382,7 +387,9 @@ final class SSEClient: @unchecked Sendable {
     private func backoffDelay(attempt: Int) -> TimeInterval {
         let idx = min(max(attempt - 1, 0), backoffSchedule.count - 1)
         let base = backoffSchedule[idx]
-        return base * jitterProvider()
+        let delay = max(0.1, base * jitterProvider())
+        Logger.info("SSE backoff attempt=\(attempt) delay=\(Int(delay * 1000))ms")
+        return delay
     }
 
     private func nanoseconds(from seconds: TimeInterval) -> UInt64 {
@@ -421,6 +428,9 @@ final class SSEClient: @unchecked Sendable {
         let last: String? = stateAccessQueue.sync { _lastEventId }
         if let last = last, !last.isEmpty {
             request.setValue(last, forHTTPHeaderField: "Last-Event-ID")
+            Logger.info("SSE sending Last-Event-ID: \(last)")
+        } else {
+            Logger.info("SSE sending Last-Event-ID: (none)")
         }
         return request
     }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
@@ -1,0 +1,402 @@
+//
+//  SSEClient.swift
+//  notifly-ios-sdk
+//
+//  서버→SDK 실시간 채널의 트랜스포트 계층.
+//  URLSession.bytes(for:) + AsyncSequence 기반으로 SSE 스트림을 수신하고
+//  지수 백오프 재연결 / heartbeat 타임아웃 / Last-Event-ID 관리를 수행한다.
+//
+
+import Foundation
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEClient: @unchecked Sendable {
+
+    // MARK: - Public types
+
+    enum State: Equatable {
+        case idle
+        case connecting
+        case open
+        case reconnecting(attempt: Int)
+        case stopped
+    }
+
+    enum ConnectionError: Error, Equatable {
+        case invalidURL
+        case invalidResponse
+        case httpStatus(Int)
+        case heartbeatTimeout
+    }
+
+    /// HTTP 응답 헤더 + line 시퀀스를 반환. 테스트는 결정적 라인 입력을 주입할 수 있다.
+    typealias StreamLineProvider = (URLRequest) async throws -> (HTTPURLResponse, AsyncThrowingStream<String, Error>)
+
+    // MARK: - Static defaults
+
+    static let defaultBackoffSchedule: [TimeInterval] = [1, 2, 4, 8, 30]
+    static let defaultHeartbeatTimeout: TimeInterval = 60
+    /// .open 이 이 시간 이상 유지된 뒤 끊기면 정상 운영 상태로 간주, 백오프 attempt 카운터를 리셋한다.
+    static let openStableThreshold: TimeInterval = 30
+
+    static func makeDefaultSession() -> URLSession {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 5
+        // 서버 Connection TTL 30분(±10%) 보다 긴 35분.
+        config.timeoutIntervalForResource = 35 * 60
+        config.waitsForConnectivity = false
+        return URLSession(configuration: config)
+    }
+
+    // MARK: - Configuration (immutable)
+
+    private let projectId: String
+    private let notiflyUserId: String
+    private let deviceId: String?
+    private let tokenProvider: () async throws -> String
+    /// nil 이면 connect 시 makeRequest 가 invalidURL throw 하여 백오프 진입.
+    /// SDK 는 host app 을 죽이지 않으므로 init 자체는 항상 성공시킨다.
+    private let baseURL: URL?
+    private let backoffSchedule: [TimeInterval]
+    private let heartbeatTimeout: TimeInterval
+    private let streamLineProvider: StreamLineProvider
+    private let jitterProvider: () -> Double
+    private let nowProvider: () -> Date
+
+    // MARK: - Mutable state (stateAccessQueue 로 보호)
+
+    private let stateAccessQueue = DispatchQueue(label: "com.notifly.sse.stateAccessQueue")
+    private var _state: State = .idle
+    private var _lastEventId: String?
+    private var _connectionTask: Task<Void, Never>?
+    private var _lastDataAt: Date
+    private var _lastOpenAt: Date?
+
+    // MARK: - Callbacks
+    //
+    // 콜백 호출은 main queue 로 dispatch 된다. 콜백 클로저 내부에서 동일 SSEClient 의
+    // setter 를 호출하면 stateAccessQueue self-recursive sync 로 deadlock 가능하니 호출자가 회피.
+
+    var onMessage: ((_ type: String, _ data: String) -> Void)? {
+        get { stateAccessQueue.sync { _onMessage } }
+        set { stateAccessQueue.sync { _onMessage = newValue } }
+    }
+    var onState: ((State) -> Void)? {
+        get { stateAccessQueue.sync { _onState } }
+        set { stateAccessQueue.sync { _onState = newValue } }
+    }
+    private var _onMessage: ((_ type: String, _ data: String) -> Void)?
+    private var _onState: ((State) -> Void)?
+
+    // MARK: - Init
+
+    init(
+        projectId: String,
+        notiflyUserId: String,
+        deviceId: String?,
+        tokenProvider: @escaping () async throws -> String,
+        session: URLSession = SSEClient.makeDefaultSession(),
+        baseURLString: String = NotiflyConstant.EndPoint.streamEndPoint,
+        backoffSchedule: [TimeInterval] = SSEClient.defaultBackoffSchedule,
+        heartbeatTimeout: TimeInterval = SSEClient.defaultHeartbeatTimeout,
+        streamLineProvider: StreamLineProvider? = nil,
+        jitterProvider: @escaping () -> Double = { Double.random(in: 0.8...1.2) },
+        nowProvider: @escaping () -> Date = { Date() }
+    ) {
+        self.projectId = projectId
+        self.notiflyUserId = notiflyUserId
+        self.deviceId = deviceId
+        self.tokenProvider = tokenProvider
+        // 잘못된 baseURLString → 컴파일타임 상수 fallback. 모두 실패해도 init 은 성공시키고
+        // connect 시점에 invalidURL throw 하도록 nil 로 둔다 (host app crash 방지).
+        let resolvedBaseURL = URL(string: baseURLString) ?? URL(string: NotiflyConstant.EndPoint.streamEndPoint)
+        if resolvedBaseURL == nil {
+            Logger.error("SSEClient: failed to resolve baseURL — connect will fail with invalidURL")
+        }
+        self.baseURL = resolvedBaseURL
+        self.backoffSchedule = backoffSchedule.isEmpty ? SSEClient.defaultBackoffSchedule : backoffSchedule
+        self.heartbeatTimeout = heartbeatTimeout
+        self.streamLineProvider = streamLineProvider ?? SSEClient.makeURLSessionStreamProvider(session: session)
+        self.jitterProvider = jitterProvider
+        self.nowProvider = nowProvider
+        self._lastDataAt = nowProvider()
+    }
+
+    private static func makeURLSessionStreamProvider(session: URLSession) -> StreamLineProvider {
+        return { request in
+            let (bytes, response) = try await session.bytes(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw ConnectionError.invalidResponse
+            }
+            let stream = AsyncThrowingStream<String, Error> { continuation in
+                let task = Task {
+                    do {
+                        for try await line in bytes.lines {
+                            continuation.yield(line)
+                        }
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+            return (http, stream)
+        }
+    }
+
+    deinit {
+        // Task.cancel() 은 thread-safe 라 stateAccessQueue 동기화 없이 호출.
+        // (deinit 안에서 자기 큐로 sync 들어가면 deadlock 가능.)
+        _connectionTask?.cancel()
+    }
+
+    // MARK: - Public API
+
+    /// 멱등. 이미 .connecting / .open / .reconnecting 이면 무시한다.
+    /// 강제 reconnect 는 disconnect() + connect() 조합으로 가능.
+    func connect() {
+        // Task 생성과 _connectionTask 할당이 한 sync 블록에 묶여야
+        // disconnect() 와 race 시 새 task 가 누락되지 않는다.
+        var didStart = false
+        stateAccessQueue.sync {
+            switch _state {
+            case .connecting, .open, .reconnecting:
+                return
+            default:
+                break
+            }
+            _connectionTask?.cancel()
+            _state = .connecting
+            let task = Task { [weak self] in
+                guard let self = self else { return }
+                await self.runConnectionLoop()
+            }
+            _connectionTask = task
+            didStart = true
+        }
+        if didStart {
+            emitState(.connecting)
+        }
+    }
+
+    /// .stopped 로 전이하고 진행 중인 연결을 취소. 이후 connect() 로 재시작 가능.
+    func disconnect() {
+        var alreadyStopped = false
+        var connTask: Task<Void, Never>?
+        stateAccessQueue.sync {
+            alreadyStopped = (_state == .stopped)
+            connTask = _connectionTask
+            _connectionTask = nil
+            _state = .stopped
+        }
+
+        connTask?.cancel()
+        if !alreadyStopped {
+            emitState(.stopped)
+        }
+    }
+
+    var state: State {
+        stateAccessQueue.sync { _state }
+    }
+
+    var lastEventId: String? {
+        stateAccessQueue.sync { _lastEventId }
+    }
+
+    // MARK: - 연결 루프
+
+    private func runConnectionLoop() async {
+        var attempt = 0
+
+        while !Task.isCancelled, !isStopped() {
+            do {
+                try await runOneConnection(attempt: attempt)
+            } catch is CancellationError {
+                break
+            } catch {
+                Logger.info("SSE connection error: \(error)")
+            }
+
+            if isStopped() || Task.isCancelled { break }
+
+            // .open 으로 충분히 오래 유지된 뒤 끊긴 경우만 정상 운영으로 간주, attempt 리셋.
+            // connecting 단계만 길어진 케이스는 백오프 누적 유지.
+            let openedAt: Date? = stateAccessQueue.sync { _lastOpenAt }
+            if let openedAt = openedAt,
+               nowProvider().timeIntervalSince(openedAt) >= SSEClient.openStableThreshold {
+                attempt = 0
+            }
+
+            attempt += 1
+            transition(to: .reconnecting(attempt: attempt))
+            let delay = backoffDelay(attempt: attempt)
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds(from: delay))
+            } catch {
+                break
+            }
+        }
+    }
+
+    private func runOneConnection(attempt: Int) async throws {
+        if attempt > 0 {
+            transition(to: .connecting)
+        }
+
+        // long-idle 후 connect() 호출 시 watchdog 가 첫 라인 받기 전에 잘못 timeout 판정하지 않도록
+        // tokenProvider 직전에 lastDataAt 을 다시 찍는다.
+        setLastDataAt(nowProvider())
+
+        let token = try await tokenProvider()
+        let request = try makeRequest(token: token)
+
+        let (http, lines) = try await streamLineProvider(request)
+        // 200 외 status (204, 304 등) 는 빈 body 로 즉시 종료 → 재연결 thrashing 유발하므로 reject.
+        guard http.statusCode == 200 else {
+            throw ConnectionError.httpStatus(http.statusCode)
+        }
+        let contentType = (http.value(forHTTPHeaderField: "Content-Type") ?? "").lowercased()
+        guard contentType.hasPrefix("text/event-stream") else {
+            throw ConnectionError.invalidResponse
+        }
+
+        transition(to: .open)
+        setLastDataAt(nowProvider())
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { [weak self] in
+                guard let self = self else { return }
+                try await self.consumeStream(lines: lines)
+            }
+            group.addTask { [weak self] in
+                guard let self = self else { return }
+                try await self.runHeartbeatWatchdog()
+            }
+            // 첫 child 완료(정상 종료 또는 throw)까지 대기 → 나머지 취소.
+            _ = try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    private func consumeStream(lines: AsyncThrowingStream<String, Error>) async throws {
+        let parser = SSELineParser()
+        for try await line in lines {
+            try Task.checkCancellation()
+            setLastDataAt(nowProvider())
+            if let event = parser.feed(line) {
+                if let id = event.id {
+                    setLastEventId(id)
+                }
+                emitMessage(type: event.type, data: event.data)
+            }
+        }
+    }
+
+    private func runHeartbeatWatchdog() async throws {
+        // timeout 의 1/4 분해능, 상한 5s — 60s timeout 이라도 worst-case 65s 안에 reconnect.
+        let checkInterval = max(min(heartbeatTimeout / 4, 5), 0.05)
+        while !Task.isCancelled {
+            try await Task.sleep(nanoseconds: nanoseconds(from: checkInterval))
+            let elapsed = nowProvider().timeIntervalSince(getLastDataAt())
+            if elapsed > heartbeatTimeout {
+                Logger.info("SSE heartbeat timeout: \(Int(elapsed))s")
+                throw ConnectionError.heartbeatTimeout
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func isStopped() -> Bool {
+        stateAccessQueue.sync { _state == .stopped }
+    }
+
+    private func transition(to new: State) {
+        let changed: Bool = stateAccessQueue.sync {
+            // .stopped 는 흡수 상태.
+            if _state == .stopped {
+                return false
+            }
+            let did = _state != new
+            _state = new
+            // .open 진입 시점만 기록. 그 외 상태에서는 stale 판정 방지를 위해 nil.
+            if case .open = new {
+                _lastOpenAt = nowProvider()
+            } else {
+                _lastOpenAt = nil
+            }
+            return did
+        }
+        if changed {
+            emitState(new)
+        }
+    }
+
+    private func emitState(_ s: State) {
+        let cb: ((State) -> Void)? = stateAccessQueue.sync { _onState }
+        DispatchQueue.main.async { cb?(s) }
+    }
+
+    private func emitMessage(type: String, data: String) {
+        let cb: ((String, String) -> Void)? = stateAccessQueue.sync { _onMessage }
+        DispatchQueue.main.async { cb?(type, data) }
+    }
+
+    private func setLastDataAt(_ d: Date) {
+        stateAccessQueue.sync { _lastDataAt = d }
+    }
+
+    private func getLastDataAt() -> Date {
+        stateAccessQueue.sync { _lastDataAt }
+    }
+
+    private func setLastEventId(_ id: String) {
+        stateAccessQueue.sync { _lastEventId = id }
+    }
+
+    private func backoffDelay(attempt: Int) -> TimeInterval {
+        let idx = min(max(attempt - 1, 0), backoffSchedule.count - 1)
+        let base = backoffSchedule[idx]
+        return base * jitterProvider()
+    }
+
+    private func nanoseconds(from seconds: TimeInterval) -> UInt64 {
+        return UInt64(max(seconds, 0) * 1_000_000_000)
+    }
+
+    private func makeRequest(token: String) throws -> URLRequest {
+        guard let baseURL = baseURL else {
+            throw ConnectionError.invalidURL
+        }
+        var components = URLComponents()
+        components.scheme = baseURL.scheme
+        components.host = baseURL.host
+        components.port = baseURL.port
+        // path component reserved/non-ASCII 대비 percent-encode.
+        let encodedProjectId = projectId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? projectId
+        let encodedUserId = notiflyUserId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? notiflyUserId
+        // baseURL.path 의 trailing slash 로 인한 // double slash 방지.
+        let normalizedBasePath = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let prefix = normalizedBasePath.isEmpty ? "" : "/\(normalizedBasePath)"
+        components.path = "\(prefix)/\(encodedProjectId)/\(encodedUserId)"
+        if let device = deviceId, !device.isEmpty {
+            components.queryItems = [URLQueryItem(name: "deviceId", value: device)]
+        }
+        guard let url = components.url else {
+            throw ConnectionError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+
+        let last: String? = stateAccessQueue.sync { _lastEventId }
+        if let last = last, !last.isEmpty {
+            request.setValue(last, forHTTPHeaderField: "Last-Event-ID")
+        }
+        return request
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEClient.swift
@@ -199,7 +199,6 @@ final class SSEClient: @unchecked Sendable {
             didStart = true
         }
         if didStart {
-            Logger.info("SSE connect requested: projectId=\(projectId) userId=\(notiflyUserId) deviceId=\(deviceId ?? "-")")
             emitState(.connecting)
         }
     }
@@ -217,7 +216,7 @@ final class SSEClient: @unchecked Sendable {
 
         connTask?.cancel()
         if !alreadyStopped {
-            Logger.info("SSE disconnect requested: projectId=\(projectId) userId=\(notiflyUserId)")
+            Logger.info("SSE disconnected")
             emitState(.stopped)
         }
     }
@@ -290,7 +289,7 @@ final class SSEClient: @unchecked Sendable {
         }
 
         transition(to: .open)
-        Logger.info("SSE connected: projectId=\(projectId) userId=\(notiflyUserId) deviceId=\(deviceId ?? "-")")
+        Logger.info("SSE connected")
         setLastDataAt(nowProvider())
 
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -329,7 +328,6 @@ final class SSEClient: @unchecked Sendable {
             try await Task.sleep(nanoseconds: nanoseconds(from: checkInterval))
             let elapsed = nowProvider().timeIntervalSince(getLastDataAt())
             if elapsed > heartbeatTimeout {
-                Logger.info("SSE heartbeat timeout: \(Int(elapsed))s")
                 throw ConnectionError.heartbeatTimeout
             }
         }
@@ -387,9 +385,7 @@ final class SSEClient: @unchecked Sendable {
     private func backoffDelay(attempt: Int) -> TimeInterval {
         let idx = min(max(attempt - 1, 0), backoffSchedule.count - 1)
         let base = backoffSchedule[idx]
-        let delay = max(0.1, base * jitterProvider())
-        Logger.info("SSE backoff attempt=\(attempt) delay=\(Int(delay * 1000))ms")
-        return delay
+        return max(0.1, base * jitterProvider())
     }
 
     private func nanoseconds(from seconds: TimeInterval) -> UInt64 {
@@ -428,9 +424,6 @@ final class SSEClient: @unchecked Sendable {
         let last: String? = stateAccessQueue.sync { _lastEventId }
         if let last = last, !last.isEmpty {
             request.setValue(last, forHTTPHeaderField: "Last-Event-ID")
-            Logger.info("SSE sending Last-Event-ID: \(last)")
-        } else {
-            Logger.info("SSE sending Last-Event-ID: (none)")
         }
         return request
     }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
@@ -1,0 +1,161 @@
+//
+//  SSEController.swift
+//  notifly-ios-sdk
+//
+
+import Foundation
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEController: @unchecked Sendable {
+
+    enum Mode: Equatable {
+        case sse
+        case fallback
+    }
+
+    // MARK: - Configuration
+
+    let sseClient: SSEClient
+    private let onSyncRequested: (@escaping () -> Void) -> Void
+    private let onServerEventTriggered: (_ name: String, _ eventParams: [String: Any]?) -> Void
+    private let scheduler: (TimeInterval, @escaping () -> Void) -> Void
+    private let syncDebounceInterval: TimeInterval
+
+    // MARK: - State
+
+    private let stateQueue = DispatchQueue(label: "com.notifly.sse.controllerStateQueue")
+    private var _mode: Mode = .sse
+    private var _hasReachedOpen: Bool = false
+    private var _pendingSyncDispatch: Bool = false
+    private var _syncInFlight: Bool = false
+    private var _generation: Int = 0
+
+    // MARK: - Init
+
+    init(
+        sseClient: SSEClient,
+        onSyncRequested: @escaping (@escaping () -> Void) -> Void,
+        onServerEventTriggered: @escaping (_ name: String, _ eventParams: [String: Any]?) -> Void,
+        syncDebounceInterval: TimeInterval = 1.0,
+        scheduler: @escaping (TimeInterval, @escaping () -> Void) -> Void = SSEController.defaultScheduler
+    ) {
+        self.sseClient = sseClient
+        self.onSyncRequested = onSyncRequested
+        self.onServerEventTriggered = onServerEventTriggered
+        self.syncDebounceInterval = syncDebounceInterval
+        self.scheduler = scheduler
+
+        sseClient.onMessage = { [weak self] type, data in
+            self?.handleMessage(type: type, data: data)
+        }
+        sseClient.onState = { [weak self] state in
+            self?.handleStateChange(state)
+        }
+    }
+
+    static let defaultScheduler: (TimeInterval, @escaping () -> Void) -> Void = { delay, work in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+
+    // MARK: - Public API
+
+    func start() {
+        sseClient.connect()
+    }
+
+    func stop() {
+        stateQueue.sync { _generation += 1 }
+        sseClient.disconnect()
+    }
+
+    func reconnect(reason: String) {
+        Logger.info("SSE reconnect requested: \(reason)")
+        sseClient.disconnect()
+        sseClient.connect()
+    }
+
+    var mode: Mode {
+        stateQueue.sync { _mode }
+    }
+
+    // MARK: - Internal handlers
+
+    func handleMessage(type: String, data: String) {
+        let message = SSEMessage.decode(type: type, data: data)
+        switch message {
+        case .connected:
+            stateQueue.sync {
+                _hasReachedOpen = true
+                _mode = .sse
+            }
+        case .sync:
+            triggerSyncStateDebounced()
+        case .event(let name, let params):
+            onServerEventTriggered(name, params)
+        case .shutdown(let ms):
+            handleShutdown(reconnectInMs: ms)
+        case .ttlExpired:
+            reconnect(reason: "ttl-expired")
+        case .unknown(let raw):
+            Logger.info("SSE unknown message type: \(raw)")
+        case .malformed(let raw):
+            Logger.error("SSE malformed message: type=\(raw)")
+        }
+    }
+
+    func handleStateChange(_ state: SSEClient.State) {
+        switch state {
+        case .open:
+            stateQueue.sync {
+                _hasReachedOpen = true
+                _mode = .sse
+            }
+        case .reconnecting(let attempt):
+            let shouldFallback: Bool = stateQueue.sync {
+                guard !_hasReachedOpen, attempt >= 3, _mode != .fallback else { return false }
+                _mode = .fallback
+                return true
+            }
+            if shouldFallback {
+                Logger.info("SSE entering fallback mode (attempt=\(attempt))")
+                sseClient.disconnect()
+            }
+        default:
+            break
+        }
+    }
+
+    // MARK: - Private
+
+    private func triggerSyncStateDebounced() {
+        let shouldDispatchNow: Bool = stateQueue.sync {
+            if _pendingSyncDispatch || _syncInFlight {
+                return false
+            }
+            _pendingSyncDispatch = true
+            _syncInFlight = true
+            return true
+        }
+        guard shouldDispatchNow else { return }
+
+        onSyncRequested { [weak self] in
+            self?.stateQueue.sync { self?._syncInFlight = false }
+        }
+        scheduler(syncDebounceInterval) { [weak self] in
+            self?.stateQueue.sync { self?._pendingSyncDispatch = false }
+        }
+    }
+
+    private func handleShutdown(reconnectInMs: Int) {
+        Logger.info("SSE shutdown received, reconnect in \(reconnectInMs)ms")
+        sseClient.disconnect()
+        let scheduledGen = stateQueue.sync { _generation }
+        let delay = max(TimeInterval(reconnectInMs) / 1000.0, 0)
+        scheduler(delay) { [weak self] in
+            guard let self = self else { return }
+            let currentGen = self.stateQueue.sync { self._generation }
+            guard currentGen == scheduledGen else { return }
+            self.sseClient.connect()
+        }
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEController.swift
@@ -69,7 +69,6 @@ final class SSEController: @unchecked Sendable {
     }
 
     func reconnect(reason: String) {
-        Logger.info("SSE reconnect requested: \(reason)")
         sseClient.disconnect()
         sseClient.connect()
     }
@@ -89,6 +88,7 @@ final class SSEController: @unchecked Sendable {
                 _mode = .sse
             }
         case .sync:
+            Logger.info("SSE sync received")
             triggerSyncStateDebounced()
         case .event(let name, let params):
             onServerEventTriggered(name, params)
@@ -96,8 +96,8 @@ final class SSEController: @unchecked Sendable {
             handleShutdown(reconnectInMs: ms)
         case .ttlExpired:
             reconnect(reason: "ttl-expired")
-        case .unknown(let raw):
-            Logger.info("SSE unknown message type: \(raw)")
+        case .unknown:
+            break
         case .malformed(let raw):
             Logger.error("SSE malformed message: type=\(raw)")
         }
@@ -117,7 +117,6 @@ final class SSEController: @unchecked Sendable {
                 return true
             }
             if shouldFallback {
-                Logger.info("SSE entering fallback mode (attempt=\(attempt))")
                 sseClient.disconnect()
             }
         default:
@@ -147,7 +146,6 @@ final class SSEController: @unchecked Sendable {
     }
 
     private func handleShutdown(reconnectInMs: Int) {
-        Logger.info("SSE shutdown received, reconnect in \(reconnectInMs)ms")
         sseClient.disconnect()
         let scheduledGen = stateQueue.sync { _generation }
         let delay = max(TimeInterval(reconnectInMs) / 1000.0, 0)

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEEvent.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEEvent.swift
@@ -1,0 +1,14 @@
+//
+//  SSEEvent.swift
+//  notifly-ios-sdk
+//
+//  Server-Sent Events 스펙(WHATWG)에 따른 단일 이벤트 표현.
+//
+
+import Foundation
+
+struct SSEEvent: Equatable {
+    let id: String?
+    let type: String
+    let data: String
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSELineParser.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSELineParser.swift
@@ -1,0 +1,85 @@
+//
+//  SSELineParser.swift
+//  notifly-ios-sdk
+//
+//  WHATWG "Server-sent events" 스펙에 따라 라인 입력을 누적해 SSEEvent 로 dispatch.
+//
+
+import Foundation
+
+final class SSELineParser {
+    private var eventType: String?
+    private var dataLines: [String] = []
+    private var isFirstLine: Bool = true
+
+    private(set) var lastEventId: String?
+
+    func feed(_ rawLine: String) -> SSEEvent? {
+        let line = stripLineEnding(rawLine)
+
+        if line.isEmpty {
+            return dispatch()
+        }
+        if line.hasPrefix(":") {
+            return nil
+        }
+
+        let (field, value) = Self.splitFieldValue(line)
+        switch field {
+        case "id":
+            // 스펙: U+0000 포함 id 는 무시.
+            if !value.contains("\0") {
+                lastEventId = value
+            }
+        case "event":
+            eventType = value
+        case "data":
+            dataLines.append(value)
+        case "retry":
+            break
+        default:
+            break
+        }
+        return nil
+    }
+
+    private func dispatch() -> SSEEvent? {
+        defer {
+            eventType = nil
+            dataLines.removeAll()
+        }
+        guard !dataLines.isEmpty else { return nil }
+        return SSEEvent(
+            id: lastEventId,
+            type: eventType ?? "message",
+            data: dataLines.joined(separator: "\n")
+        )
+    }
+
+    private func stripLineEnding(_ s: String) -> String {
+        var result = s
+        if result.hasSuffix("\r") {
+            result.removeLast()
+        }
+        // 스펙: BOM 은 스트림 첫 라인에만 제거. 이후 라인의 U+FEFF 는 데이터로 보존.
+        if isFirstLine {
+            if result.first == "\u{FEFF}" {
+                result.removeFirst()
+            }
+            isFirstLine = false
+        }
+        return result
+    }
+
+    private static func splitFieldValue(_ line: String) -> (String, String) {
+        guard let colonIdx = line.firstIndex(of: ":") else {
+            return (line, "")
+        }
+        let field = String(line[..<colonIdx])
+        var valueStart = line.index(after: colonIdx)
+        if valueStart < line.endIndex, line[valueStart] == " " {
+            valueStart = line.index(after: valueStart)
+        }
+        return (field, String(line[valueStart...]))
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEMessage.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/SSE/SSEMessage.swift
@@ -1,0 +1,49 @@
+//
+//  SSEMessage.swift
+//  notifly-ios-sdk
+//
+
+import Foundation
+
+enum SSEMessage {
+    case connected
+    case sync
+    case event(name: String, eventParams: [String: Any]?)
+    case shutdown(reconnectInMs: Int)
+    case ttlExpired
+    case unknown(rawType: String)
+    case malformed(rawType: String)
+
+    static func decode(type: String, data: String) -> SSEMessage {
+        switch type {
+        case "connected":
+            return .connected
+        case "sync":
+            return .sync
+        case "server-event":
+            guard let json = parseJSON(data),
+                  let name = json["name"] as? String else {
+                return .malformed(rawType: type)
+            }
+            let params = json["eventParams"] as? [String: Any]
+            return .event(name: name, eventParams: params)
+        case "shutdown":
+            // Int / Double / NSNumber 모두 허용 (서버가 1000 또는 1000.0 둘 다 보낼 수 있음).
+            let raw = parseJSON(data)?["reconnectInMs"]
+            let ms: Int = (raw as? Int)
+                ?? (raw as? NSNumber)?.intValue
+                ?? (raw as? Double).map { Int($0) }
+                ?? 0
+            return .shutdown(reconnectInMs: max(ms, 0))
+        case "ttl-expired":
+            return .ttlExpired
+        default:
+            return .unknown(rawType: type)
+        }
+    }
+
+    private static func parseJSON(_ data: String) -> [String: Any]? {
+        guard let raw = data.data(using: .utf8) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: raw)) as? [String: Any]
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -71,6 +71,12 @@ import UIKit
             Logger.info("📡 Notifly SDK is successfully initialized.")
             finishTask()
         }
+
+        Notifly.asyncWorker.addTask { finishTask in
+            main.registerSSELifecycleObservers()
+            main.startSSE()
+            finishTask()
+        }
     }
 
     static func application(
@@ -192,6 +198,10 @@ import UIKit
             return
         }
         main.userManager.setExternalUserId(userId)
+        Notifly.asyncWorker.addTask { finishTask in
+            main.restartSSE()
+            finishTask()
+        }
     }
 
     static func getNotiflyUserId() -> String? {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
@@ -68,7 +68,7 @@ extension Notifly {
 
     func stopSSE() {
         let current: SSEController? = sseAccessQueue.sync { _sseController }
-        current?.sseClient.disconnect()
+        current?.stop()
     }
 
     func restartSSE() {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
@@ -1,0 +1,136 @@
+//
+//  Notifly+SSE.swift
+//  notifly-ios-sdk
+//
+
+import Combine
+import Foundation
+import UIKit
+
+@available(iOSApplicationExtension, unavailable)
+extension Notifly {
+
+    func startSSE() {
+        guard !Notifly.inAppMessageDisabled else { return }
+        guard let notiflyUserId = try? userManager.getNotiflyUserID() else {
+            Logger.info("SSE: skip start — no notifly user id yet")
+            return
+        }
+        let deviceId = AppHelper.getNotiflyDeviceID()
+        let auth = self.auth
+        let userStateManager = inAppMessageManager.userStateManager
+        let inAppMgr = inAppMessageManager
+
+        let client = SSEClient(
+            projectId: projectId,
+            notiflyUserId: notiflyUserId,
+            deviceId: deviceId,
+            tokenProvider: { [weak auth] in
+                guard let auth = auth else { throw NotiflyError.notInitialized }
+                return try await Notifly.fetchAuthorizationToken(auth: auth)
+            }
+        )
+
+        let controller = SSEController(
+            sseClient: client,
+            onSyncRequested: { [weak userStateManager] completion in
+                guard let mgr = userStateManager else {
+                    completion()
+                    return
+                }
+                mgr.syncState(
+                    postProcessConfig: PostProcessConfigForSyncState(merge: true, clear: false)
+                ) {
+                    completion()
+                }
+            },
+            onServerEventTriggered: { [weak inAppMgr] name, params in
+                inAppMgr?.mayTriggerInAppMessage(
+                    eventName: name,
+                    eventParams: params,
+                    segmentationEventParamKeys: nil
+                )
+            }
+        )
+
+        sseAccessQueue.sync {
+            _sseController?.stop()
+            _sseController = controller
+            controller.start()
+        }
+    }
+
+    func stopSSE() {
+        let previous: SSEController? = sseAccessQueue.sync {
+            let c = _sseController
+            _sseController = nil
+            return c
+        }
+        previous?.stop()
+    }
+
+    func restartSSE() {
+        startSSE()
+    }
+
+    func registerSSELifecycleObservers() {
+        let shouldRegister: Bool = sseAccessQueue.sync {
+            if _sseObserversRegistered { return false }
+            _sseObserversRegistered = true
+            return true
+        }
+        guard shouldRegister else { return }
+
+        let center = NotificationCenter.default
+        let bgToken = center.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.stopSSE()
+        }
+        let fgToken = center.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            self?.startSSE()
+        }
+        sseAccessQueue.sync {
+            _sseLifecycleObserverTokens = [bgToken, fgToken]
+        }
+    }
+
+    func unregisterSSELifecycleObservers() {
+        let tokens: [NSObjectProtocol] = sseAccessQueue.sync {
+            let t = _sseLifecycleObserverTokens
+            _sseLifecycleObserverTokens = []
+            _sseObserversRegistered = false
+            return t
+        }
+        let center = NotificationCenter.default
+        for token in tokens {
+            center.removeObserver(token)
+        }
+    }
+
+    private static func fetchAuthorizationToken(auth: Auth) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                for try await token in auth.authorizationPub.first().values {
+                    return token
+                }
+                throw NotiflyError.notAuthorized
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 10_000_000_000)
+                throw NotiflyError.notAuthorized
+            }
+            defer { group.cancelAll() }
+            guard let first = try await group.next() else {
+                throw NotiflyError.notAuthorized
+            }
+            return first
+        }
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+SSE.swift
@@ -16,6 +16,13 @@ extension Notifly {
             Logger.info("SSE: skip start — no notifly user id yet")
             return
         }
+
+        let existing: SSEController? = sseAccessQueue.sync { _sseController }
+        if let existing = existing {
+            existing.start()
+            return
+        }
+
         let deviceId = AppHelper.getNotiflyDeviceID()
         let auth = self.auth
         let userStateManager = inAppMessageManager.userStateManager
@@ -54,22 +61,23 @@ extension Notifly {
         )
 
         sseAccessQueue.sync {
-            _sseController?.stop()
             _sseController = controller
-            controller.start()
         }
+        controller.start()
     }
 
     func stopSSE() {
+        let current: SSEController? = sseAccessQueue.sync { _sseController }
+        current?.sseClient.disconnect()
+    }
+
+    func restartSSE() {
         let previous: SSEController? = sseAccessQueue.sync {
             let c = _sseController
             _sseController = nil
             return c
         }
         previous?.stop()
-    }
-
-    func restartSSE() {
         startSSE()
     }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
@@ -34,6 +34,11 @@ import UIKit
     let userManager: UserManager
     let inAppMessageManager: InAppMessageManager
 
+    let sseAccessQueue = DispatchQueue(label: "com.notifly.sse.access.queue")
+    var _sseController: SSEController?
+    var _sseLifecycleObserverTokens: [NSObjectProtocol] = []
+    var _sseObserversRegistered: Bool = false
+
     // MARK: Lifecycle
 
     init(

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -15,7 +15,7 @@ enum NotiflyConstant {
             "https://e.notifly.tech/records"
         static let syncStateEndPoint = "https://api.notifly.tech/user-state"
         static let authorizationEndPoint = "https://api.notifly.tech/authorize"
-        static let streamEndPoint = "https://api.notifly.tech/streams"
+        static let streamEndPoint = "https://api.notifly.tech"
     }
 }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -13,9 +13,9 @@ enum NotiflyConstant {
     enum EndPoint {
         static let trackEventEndPoint =
             "https://e.notifly.tech/records"
-        static let syncStateEndPoint = "https://api-stage.notifly.tech/user-state"
-        static let authorizationEndPoint = "https://api-stage.notifly.tech/authorize"
-        static let streamEndPoint = "https://api-stage.notifly.tech"
+        static let syncStateEndPoint = "https://api.notifly.tech/user-state"
+        static let authorizationEndPoint = "https://api.notifly.tech/authorize"
+        static let streamEndPoint = "https://api.notifly.tech"
     }
 }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -15,6 +15,7 @@ enum NotiflyConstant {
             "https://e.notifly.tech/records"
         static let syncStateEndPoint = "https://api.notifly.tech/user-state"
         static let authorizationEndPoint = "https://api.notifly.tech/authorize"
+        static let streamEndPoint = "https://api.notifly.tech/streams"
     }
 }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "2.4.0"
+    static let sdkVersion: String = "2.5.0"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?
@@ -13,9 +13,9 @@ enum NotiflyConstant {
     enum EndPoint {
         static let trackEventEndPoint =
             "https://e.notifly.tech/records"
-        static let syncStateEndPoint = "https://api.notifly.tech/user-state"
-        static let authorizationEndPoint = "https://api.notifly.tech/authorize"
-        static let streamEndPoint = "https://api.notifly.tech"
+        static let syncStateEndPoint = "https://api-stage.notifly.tech/user-state"
+        static let authorizationEndPoint = "https://api-stage.notifly.tech/authorize"
+        static let streamEndPoint = "https://api-stage.notifly.tech"
     }
 }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEByteLineSplitterTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEByteLineSplitterTests.swift
@@ -1,0 +1,171 @@
+//
+//  SSEByteLineSplitterTests.swift
+//  notifly-ios-sdkTests
+//
+//  WHATWG SSE spec 의 line-splitting (LF / CR / CRLF) + 빈 라인 yield 검증.
+//  LaunchDarkly swift-eventsource 의 UTF8LineParserTests 케이스를 미러링.
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEByteLineSplitterTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func split(_ bytes: [UInt8]) async throws -> [String] {
+        let source = AsyncStream<UInt8> { continuation in
+            for b in bytes { continuation.yield(b) }
+            continuation.finish()
+        }
+        var lines: [String] = []
+        for try await line in SSEClient.splitSSELines(source) {
+            lines.append(line)
+        }
+        return lines
+    }
+
+    private func split(_ s: String) async throws -> [String] {
+        try await split(Array(s.utf8))
+    }
+
+    // MARK: - 기본 terminator
+
+    func test_lfOnly_yieldsSingleEmptyLine() async throws {
+        let out = try await split("\n")
+        XCTAssertEqual(out, [""])
+    }
+
+    func test_crOnly_yieldsSingleEmptyLine() async throws {
+        let out = try await split("\r")
+        XCTAssertEqual(out, [""])
+    }
+
+    func test_crlf_yieldsSingleEmptyLine() async throws {
+        let out = try await split("\r\n")
+        XCTAssertEqual(out, [""])
+    }
+
+    func test_singleLine_lf() async throws {
+        let out = try await split("hello\n")
+        XCTAssertEqual(out, ["hello"])
+    }
+
+    func test_singleLine_cr() async throws {
+        let out = try await split("hello\r")
+        XCTAssertEqual(out, ["hello"])
+    }
+
+    func test_singleLine_crlf() async throws {
+        let out = try await split("hello\r\n")
+        XCTAssertEqual(out, ["hello"])
+    }
+
+    // MARK: - EOF discard (WHATWG: pending data must be discarded)
+
+    func test_unterminatedTail_isDiscarded() async throws {
+        let out = try await split("hello")
+        XCTAssertEqual(out, [])
+    }
+
+    func test_terminatedThenUnterminated_yieldsOnlyTerminated() async throws {
+        let out = try await split("a\nbcd")
+        XCTAssertEqual(out, ["a"])
+    }
+
+    // MARK: - mixed line endings
+
+    func test_mixedLineEndings_inSingleStream() async throws {
+        let out = try await split("a\nb\r\nc\rd\n")
+        XCTAssertEqual(out, ["a", "b", "c", "d"])
+    }
+
+    // MARK: - 연속 blank line — SSE event terminator 핵심 케이스
+
+    func test_consecutiveLF_yieldsMultipleBlankLines() async throws {
+        let out = try await split("\n\n\n")
+        XCTAssertEqual(out, ["", "", ""])
+    }
+
+    func test_consecutiveCRLF_yieldsMultipleBlankLines() async throws {
+        let out = try await split("\r\n\r\n")
+        XCTAssertEqual(out, ["", ""])
+    }
+
+    func test_blankLineBetweenContent() async throws {
+        let out = try await split("a\n\nb\n")
+        XCTAssertEqual(out, ["a", "", "b"])
+    }
+
+    func test_sseEventBlock_endsWithBlankLine() async throws {
+        // 우리가 고치는 핵심 시나리오 — server 가 보낸 event terminator 가 SDK 까지 보존.
+        let out = try await split("event: sync\ndata: {}\n\n")
+        XCTAssertEqual(out, ["event: sync", "data: {}", ""])
+    }
+
+    // MARK: - CR 직후 비-LF byte
+
+    func test_crFollowedByText_treatsCRAsTerminator() async throws {
+        // \r 직후 text → \r 이 line terminator 로 작동, 'b' 는 다음 라인 시작
+        let out = try await split("a\rb\n")
+        XCTAssertEqual(out, ["a", "b"])
+    }
+
+    func test_crFollowedByCR_eachIsTerminator() async throws {
+        let out = try await split("a\r\rb\n")
+        XCTAssertEqual(out, ["a", "", "b"])
+    }
+
+    func test_lfFollowedByCR_eachIsTerminator() async throws {
+        // \n 다음 \r — prevWasCR 가 set 되지 않은 상태라 \r 가 독립적 terminator
+        let out = try await split("a\n\rb\n")
+        XCTAssertEqual(out, ["a", "", "b"])
+    }
+
+    // MARK: - unicode 보존
+
+    func test_unicodeContent_preserved() async throws {
+        let out = try await split("안녕하세요\n")
+        XCTAssertEqual(out, ["안녕하세요"])
+    }
+
+    func test_emojiContent_preserved() async throws {
+        let out = try await split("hi 🚀\n")
+        XCTAssertEqual(out, ["hi 🚀"])
+    }
+
+    func test_diacritics_preserved() async throws {
+        let out = try await split("café\n")
+        XCTAssertEqual(out, ["café"])
+    }
+
+    // MARK: - 통합 SSE 시나리오 — server 가 실제 보내는 형태
+
+    func test_realisticSSEEventStream() async throws {
+        // 두 개의 event block (connected, sync) + heartbeat comment.
+        // 각 블록은 blank line 으로 종료된다. (Swift multiline literal 은 closing """ 직전의
+        // 줄바꿈을 자동 제거하므로 마지막 terminator 는 명시적으로 \n 추가한다.)
+        let stream = "event: connected\n"
+            + "data: {\"projectId\":\"abc\"}\n"
+            + "\n"
+            + "id: 42\n"
+            + "event: sync\n"
+            + "data: {}\n"
+            + "\n"
+            + ": heartbeat\n"
+            + "\n"
+        let out = try await split(stream)
+        XCTAssertEqual(out, [
+            "event: connected",
+            "data: {\"projectId\":\"abc\"}",
+            "",
+            "id: 42",
+            "event: sync",
+            "data: {}",
+            "",
+            ": heartbeat",
+            "",
+        ])
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientResponseValidationTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientResponseValidationTests.swift
@@ -1,0 +1,74 @@
+//
+//  SSEClientResponseValidationTests.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEClientResponseValidationTests: XCTestCase {
+
+    func test_204NoContent_isRejectedAndBacksOff() {
+        let pb = ProviderBuilder()
+        pb.enqueueNoContent(204)
+        pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "204 → backoff → second connect") {
+            pb.capturedRequestCount >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            },
+            "Expected .reconnecting after 204 in \(recorder.snapshot)"
+        )
+
+        client.disconnect()
+    }
+
+    func test_wrongContentType_isRejectedAndBacksOff() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpenWithContentType("application/json")
+        pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "wrong content-type → backoff → second connect") {
+            pb.capturedRequestCount >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            }
+        )
+
+        client.disconnect()
+    }
+
+    func test_eventStreamWithCharsetParam_isAccepted() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpenWithContentType("text/event-stream; charset=utf-8")
+
+        let opened = expectation(description: "opened")
+        let client = makeSSEClient(provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+        client.disconnect()
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
@@ -142,7 +142,7 @@ extension XCTestCase {
             notiflyUserId: "user-42",
             deviceId: deviceId,
             tokenProvider: token,
-            baseURLString: "https://test.local/streams",
+            baseURLString: "https://test.local",
             backoffSchedule: backoff,
             heartbeatTimeout: heartbeatTimeout,
             streamLineProvider: provider,

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTestSupport.swift
@@ -1,0 +1,209 @@
+//
+//  SSEClientTestSupport.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class TestStream: @unchecked Sendable {
+    let continuation: AsyncThrowingStream<String, Error>.Continuation
+    let stream: AsyncThrowingStream<String, Error>
+
+    init() {
+        var contRef: AsyncThrowingStream<String, Error>.Continuation!
+        self.stream = AsyncThrowingStream<String, Error> { c in contRef = c }
+        self.continuation = contRef
+    }
+
+    func write(_ line: String) {
+        continuation.yield(line)
+    }
+
+    func writeBlock(_ block: String) {
+        for line in block.components(separatedBy: "\n") {
+            continuation.yield(line)
+        }
+    }
+
+    func finish() {
+        continuation.finish()
+    }
+
+    func fail(_ error: Error) {
+        continuation.finish(throwing: error)
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+struct ProviderScenario {
+    var statusCode: Int = 200
+    var contentType: String = "text/event-stream"
+    var stream: TestStream?
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class ProviderBuilder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var scenarios: [ProviderScenario] = []
+    private var _capturedRequests: [URLRequest] = []
+    var onRequest: ((URLRequest) -> Void)?
+
+    var capturedRequestCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _capturedRequests.count
+    }
+
+    var capturedRequestsSnapshot: [URLRequest] {
+        lock.lock(); defer { lock.unlock() }
+        return _capturedRequests
+    }
+
+    func enqueue(_ scenario: ProviderScenario) {
+        lock.lock(); defer { lock.unlock() }
+        scenarios.append(scenario)
+    }
+
+    @discardableResult
+    func enqueueOpen(stream: TestStream = TestStream()) -> TestStream {
+        enqueue(ProviderScenario(statusCode: 200, stream: stream))
+        return stream
+    }
+
+    @discardableResult
+    func enqueueOpenWithContentType(_ contentType: String, stream: TestStream = TestStream()) -> TestStream {
+        enqueue(ProviderScenario(statusCode: 200, contentType: contentType, stream: stream))
+        return stream
+    }
+
+    func enqueueHTTPError(_ code: Int) {
+        enqueue(ProviderScenario(statusCode: code, stream: nil))
+    }
+
+    func enqueueNoContent(_ code: Int = 204) {
+        enqueue(ProviderScenario(statusCode: code, stream: nil))
+    }
+
+    func makeProvider() -> SSEClient.StreamLineProvider {
+        return { [weak self] request in
+            guard let self = self else { throw SSEClient.ConnectionError.invalidResponse }
+            self.lock.lock()
+            self._capturedRequests.append(request)
+            let cb = self.onRequest
+            let scenario = self.scenarios.isEmpty
+                ? ProviderScenario(statusCode: 500, stream: nil)
+                : self.scenarios.removeFirst()
+            self.lock.unlock()
+            cb?(request)
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: scenario.statusCode,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": scenario.contentType]
+            )!
+            let stream = scenario.stream?.stream ?? AsyncThrowingStream<String, Error> { c in
+                c.finish()
+            }
+            return (response, stream)
+        }
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+final class StateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var states: [SSEClient.State] = []
+
+    func append(_ s: SSEClient.State) {
+        lock.lock(); defer { lock.unlock() }
+        states.append(s)
+    }
+
+    var snapshot: [SSEClient.State] {
+        lock.lock(); defer { lock.unlock() }
+        return states
+    }
+}
+
+@available(iOSApplicationExtension, unavailable)
+extension XCTestCase {
+
+    func makeSSEClient(
+        deviceId: String? = "device-1",
+        backoff: [TimeInterval] = [0.05],
+        heartbeatTimeout: TimeInterval = SSEClient.defaultHeartbeatTimeout,
+        token: @escaping () async throws -> String = { "test-token" },
+        provider: @escaping SSEClient.StreamLineProvider
+    ) -> SSEClient {
+        return SSEClient(
+            projectId: "00000000000000000000000000000abc",
+            notiflyUserId: "user-42",
+            deviceId: deviceId,
+            tokenProvider: token,
+            baseURLString: "https://test.local/streams",
+            backoffSchedule: backoff,
+            heartbeatTimeout: heartbeatTimeout,
+            streamLineProvider: provider,
+            jitterProvider: { 1.0 }
+        )
+    }
+
+    func waitForCondition(
+        timeout: TimeInterval = 3,
+        description: String = "condition",
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ check: @escaping () -> Bool
+    ) {
+        let exp = expectation(description: description)
+        let queue = DispatchQueue.global()
+        let lock = NSLock()
+        var fulfilled = false
+        var timedOut = false
+        let deadline = Date().addingTimeInterval(timeout)
+        func tick() {
+            queue.asyncAfter(deadline: .now() + 0.02) {
+                lock.lock()
+                if fulfilled {
+                    lock.unlock()
+                    return
+                }
+                lock.unlock()
+                if check() {
+                    lock.lock()
+                    if !fulfilled {
+                        fulfilled = true
+                        lock.unlock()
+                        exp.fulfill()
+                    } else {
+                        lock.unlock()
+                    }
+                    return
+                }
+                if Date() < deadline {
+                    tick()
+                } else {
+                    lock.lock()
+                    if !fulfilled {
+                        fulfilled = true
+                        timedOut = true
+                        lock.unlock()
+                        exp.fulfill()
+                    } else {
+                        lock.unlock()
+                    }
+                }
+            }
+        }
+        tick()
+        wait(for: [exp], timeout: timeout + 1)
+        lock.lock()
+        let didTimeOut = timedOut
+        lock.unlock()
+        if didTimeOut {
+            XCTFail("waitForCondition timed out: \(description)", file: file, line: line)
+        }
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
@@ -1,0 +1,302 @@
+//
+//  SSEClientTests.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEClientTests: XCTestCase {
+
+    // MARK: - 기본
+
+    func test_initialState_isIdle() {
+        let pb = ProviderBuilder()
+        let client = makeSSEClient(provider: pb.makeProvider())
+        XCTAssertEqual(client.state, .idle)
+        XCTAssertNil(client.lastEventId)
+    }
+
+    func test_connect_transitionsThroughConnectingToOpen() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let openExp = expectation(description: "open")
+        let client = makeSSEClient(provider: pb.makeProvider())
+        client.onState = { state in
+            recorder.append(state)
+            if state == .open { openExp.fulfill() }
+        }
+        client.connect()
+        wait(for: [openExp], timeout: 3)
+
+        XCTAssertEqual(recorder.snapshot.first, .connecting)
+        XCTAssertTrue(recorder.snapshot.contains(.open))
+
+        client.disconnect()
+    }
+
+    func test_connect_emitsMessageOnReceivedEvent() {
+        let pb = ProviderBuilder()
+        let stream = pb.enqueueOpen()
+
+        let messageExp = expectation(description: "message")
+        var receivedType: String?
+        var receivedData: String?
+
+        let client = makeSSEClient(provider: pb.makeProvider())
+        client.onMessage = { type, data in
+            receivedType = type
+            receivedData = data
+            messageExp.fulfill()
+        }
+        client.connect()
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+            stream.writeBlock("event: connected\ndata: {\"projectId\":\"abc\"}\n")
+            stream.write("")
+        }
+
+        wait(for: [messageExp], timeout: 3)
+        XCTAssertEqual(receivedType, "connected")
+        XCTAssertEqual(receivedData, "{\"projectId\":\"abc\"}")
+
+        client.disconnect()
+    }
+
+    func test_request_buildsBearerAndAcceptHeaders_andURLPath() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+
+        let opened = expectation(description: "open")
+        let client = makeSSEClient(token: { "my-token" }, provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+
+        let captured = pb.capturedRequestsSnapshot.first
+        XCTAssertNotNil(captured)
+        XCTAssertEqual(captured?.value(forHTTPHeaderField: "Authorization"), "Bearer my-token")
+        XCTAssertEqual(captured?.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+        XCTAssertNil(captured?.value(forHTTPHeaderField: "Last-Event-ID"))
+        XCTAssertEqual(captured?.url?.path, "/streams/00000000000000000000000000000abc/user-42")
+        XCTAssertEqual(captured?.url?.query, "deviceId=device-1")
+
+        client.disconnect()
+    }
+
+    func test_request_omitsDeviceIdQueryWhenNil() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+
+        let opened = expectation(description: "open")
+        let client = makeSSEClient(deviceId: nil, provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+
+        XCTAssertNil(pb.capturedRequestsSnapshot.first?.url?.query)
+        client.disconnect()
+    }
+
+    // MARK: - Last-Event-ID 재연결
+
+    func test_reconnect_includesLastEventIdHeader() {
+        let pb = ProviderBuilder()
+        let firstStream = pb.enqueueOpen()
+        pb.enqueueOpen()
+
+        let firstReceived = expectation(description: "first event")
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onMessage = { _, _ in firstReceived.fulfill() }
+        client.connect()
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+            firstStream.writeBlock("id: 42\nevent: sync\ndata: {}\n")
+            firstStream.write("")
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                firstStream.finish()
+            }
+        }
+
+        wait(for: [firstReceived], timeout: 3)
+        waitForCondition(description: "second request") { pb.capturedRequestCount >= 2 }
+
+        let secondRequest = pb.capturedRequestsSnapshot[1]
+        XCTAssertEqual(secondRequest.value(forHTTPHeaderField: "Last-Event-ID"), "42")
+        XCTAssertEqual(client.lastEventId, "42")
+
+        client.disconnect()
+    }
+
+    // MARK: - HTTP 에러 / 백오프
+
+    func test_httpError_triggersReconnect() {
+        let pb = ProviderBuilder()
+        pb.enqueueHTTPError(503)
+        pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeSSEClient(backoff: [0.02], provider: pb.makeProvider())
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(description: "second request after 503") {
+            pb.capturedRequestCount >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            },
+            "Expected .reconnecting in \(recorder.snapshot)"
+        )
+
+        client.disconnect()
+    }
+
+    // MARK: - 멱등성 / disconnect
+
+    func test_connect_isIdempotentWhileConnected() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+
+        let opened = expectation(description: "opened")
+        let client = makeSSEClient(provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+
+        client.connect()
+        client.connect()
+
+        let assertion = expectation(description: "no extra request")
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) {
+            assertion.fulfill()
+        }
+        wait(for: [assertion], timeout: 2)
+        XCTAssertEqual(pb.capturedRequestCount, 1)
+
+        client.disconnect()
+    }
+
+    func test_disconnect_transitionsToStopped() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+
+        let opened = expectation(description: "opened")
+        let stopped = expectation(description: "stopped")
+        let client = makeSSEClient(provider: pb.makeProvider())
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+            if state == .stopped { stopped.fulfill() }
+        }
+
+        client.connect()
+        wait(for: [opened], timeout: 3)
+        client.disconnect()
+        wait(for: [stopped], timeout: 3)
+        XCTAssertEqual(client.state, .stopped)
+    }
+
+    func test_disconnect_thenConnect_restartsLoop() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+        pb.enqueueOpen()
+
+        let firstOpen = expectation(description: "first open")
+        firstOpen.assertForOverFulfill = false
+        let secondOpen = expectation(description: "second open")
+        secondOpen.assertForOverFulfill = false
+
+        let client = makeSSEClient(provider: pb.makeProvider())
+        let counterQueue = DispatchQueue(label: "test.openCounter")
+        var seenOpenCount = 0
+        client.onState = { state in
+            guard state == .open else { return }
+            counterQueue.sync {
+                seenOpenCount += 1
+                if seenOpenCount == 1 { firstOpen.fulfill() }
+                if seenOpenCount == 2 { secondOpen.fulfill() }
+            }
+        }
+        client.connect()
+        wait(for: [firstOpen], timeout: 3)
+        client.disconnect()
+        client.connect()
+        wait(for: [secondOpen], timeout: 3)
+
+        XCTAssertEqual(pb.capturedRequestCount, 2)
+        client.disconnect()
+    }
+
+    // MARK: - Heartbeat watchdog
+
+    func test_heartbeatTimeout_triggersReconnect() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+        pb.enqueueOpen()
+
+        let recorder = StateRecorder()
+        let client = makeSSEClient(
+            backoff: [0.02],
+            heartbeatTimeout: 0.3,
+            provider: pb.makeProvider()
+        )
+        client.onState = { recorder.append($0) }
+        client.connect()
+
+        waitForCondition(timeout: 5, description: "second request after heartbeat") {
+            pb.capturedRequestCount >= 2
+        }
+
+        XCTAssertTrue(
+            recorder.snapshot.contains { state in
+                if case .reconnecting = state { return true }
+                return false
+            },
+            "Expected .reconnecting after heartbeat timeout in \(recorder.snapshot)"
+        )
+
+        client.disconnect()
+    }
+
+    // MARK: - 토큰 에러
+
+    func test_tokenProviderThrows_loopRecoversOnNextAttempt() {
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+
+        var attempt = 0
+        let lock = NSLock()
+        let client = makeSSEClient(
+            backoff: [0.02],
+            token: {
+                lock.lock(); defer { lock.unlock() }
+                attempt += 1
+                if attempt == 1 { throw NSError(domain: "Test", code: 1) }
+                return "ok-token"
+            },
+            provider: pb.makeProvider()
+        )
+
+        let opened = expectation(description: "opened on retry")
+        client.onState = { state in
+            if state == .open { opened.fulfill() }
+        }
+        client.connect()
+        wait(for: [opened], timeout: 3)
+        // tokenProvider 실패는 request 가 만들어지기 전이라 capturedRequests 1건만.
+        XCTAssertEqual(pb.capturedRequestCount, 1)
+        client.disconnect()
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEClientTests.swift
@@ -83,7 +83,7 @@ final class SSEClientTests: XCTestCase {
         XCTAssertEqual(captured?.value(forHTTPHeaderField: "Authorization"), "Bearer my-token")
         XCTAssertEqual(captured?.value(forHTTPHeaderField: "Accept"), "text/event-stream")
         XCTAssertNil(captured?.value(forHTTPHeaderField: "Last-Event-ID"))
-        XCTAssertEqual(captured?.url?.path, "/streams/00000000000000000000000000000abc/user-42")
+        XCTAssertEqual(captured?.url?.path, "/projects/00000000000000000000000000000abc/users/user-42/streams")
         XCTAssertEqual(captured?.url?.query, "deviceId=device-1")
 
         client.disconnect()

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
@@ -57,7 +57,7 @@ final class SSEControllerTests: XCTestCase {
             notiflyUserId: "u",
             deviceId: nil,
             tokenProvider: { "t" },
-            baseURLString: "https://test.local/streams",
+            baseURLString: "https://test.local",
             streamLineProvider: { _ in
                 throw NSError(domain: "should-not-be-called", code: 0)
             }

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEControllerTests.swift
@@ -1,0 +1,275 @@
+//
+//  SSEControllerTests.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+@available(iOSApplicationExtension, unavailable)
+final class SSEControllerTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private final class Spy: @unchecked Sendable {
+        let lock = NSLock()
+        private var _syncRequestedCount = 0
+        private var _eventCalls: [(String, [String: Any]?)] = []
+        private var _scheduledTasks: [(TimeInterval, () -> Void)] = []
+
+        var syncRequestedCount: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _syncRequestedCount
+        }
+        var eventCalls: [(String, [String: Any]?)] {
+            lock.lock(); defer { lock.unlock() }
+            return _eventCalls
+        }
+
+        func recordSync() {
+            lock.lock(); defer { lock.unlock() }
+            _syncRequestedCount += 1
+        }
+        func recordEvent(_ name: String, _ params: [String: Any]?) {
+            lock.lock(); defer { lock.unlock() }
+            _eventCalls.append((name, params))
+        }
+        func scheduleTask(_ delay: TimeInterval, _ work: @escaping () -> Void) {
+            lock.lock()
+            _scheduledTasks.append((delay, work))
+            lock.unlock()
+        }
+        /// 디바운스 윈도우 만료를 흉내내기 위해 즉시 실행.
+        func flushScheduled() {
+            lock.lock()
+            let tasks = _scheduledTasks
+            _scheduledTasks.removeAll()
+            lock.unlock()
+            for (_, work) in tasks { work() }
+        }
+    }
+
+    private func makeDummySSEClient() -> SSEClient {
+        // streamLineProvider 는 connect() 호출 시에만 발동.
+        // 본 테스트는 connect() 를 호출하지 않으므로 throw stub 으로 둔다.
+        return SSEClient(
+            projectId: "00000000000000000000000000000abc",
+            notiflyUserId: "u",
+            deviceId: nil,
+            tokenProvider: { "t" },
+            baseURLString: "https://test.local/streams",
+            streamLineProvider: { _ in
+                throw NSError(domain: "should-not-be-called", code: 0)
+            }
+        )
+    }
+
+    private func makeController(
+        spy: Spy,
+        debounce: TimeInterval = 1.0
+    ) -> SSEController {
+        let client = makeDummySSEClient()
+        return SSEController(
+            sseClient: client,
+            onSyncRequested: { completion in
+                spy.recordSync()
+                completion()
+            },
+            onServerEventTriggered: { name, params in
+                spy.recordEvent(name, params)
+            },
+            syncDebounceInterval: debounce,
+            scheduler: { delay, work in
+                spy.scheduleTask(delay, work)
+            }
+        )
+    }
+
+    // MARK: - sync routing + 디바운스
+
+    func test_sync_singleMessage_triggersSyncOnce() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+    }
+
+    func test_sync_burstWithinDebounce_triggersSyncOnce() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "sync", data: "{}")
+        controller.handleMessage(type: "sync", data: "{}")
+        controller.handleMessage(type: "sync", data: "{}")
+
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+    }
+
+    func test_shutdown_scheduledReconnectSkipsAfterStop() {
+        let spy = Spy()
+        let pb = ProviderBuilder()
+        pb.enqueueOpen()
+        let client = makeSSEClient(provider: pb.makeProvider())
+        let controller = SSEController(
+            sseClient: client,
+            onSyncRequested: { completion in
+                spy.recordSync()
+                completion()
+            },
+            onServerEventTriggered: { _, _ in },
+            scheduler: { delay, work in spy.scheduleTask(delay, work) }
+        )
+
+        controller.handleMessage(type: "shutdown", data: "{\"reconnectInMs\":2000}")
+        controller.stop()
+        spy.flushScheduled()
+
+        // controller.stop() 후 scheduled fire 시 새 connect 시도가 일어나지 않아야 한다.
+        XCTAssertEqual(pb.capturedRequestCount, 0)
+    }
+
+    func test_sync_blockedByInFlightEvenAfterDebounceWindow() {
+        let spy = Spy()
+        var heldCompletion: (() -> Void)?
+        let controller = SSEController(
+            sseClient: makeDummySSEClient(),
+            onSyncRequested: { completion in
+                spy.recordSync()
+                heldCompletion = completion
+            },
+            onServerEventTriggered: { _, _ in },
+            syncDebounceInterval: 1.0,
+            scheduler: { delay, work in spy.scheduleTask(delay, work) }
+        )
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+
+        spy.flushScheduled()
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+
+        heldCompletion?()
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 2)
+    }
+
+    func test_sync_afterDebounceWindow_triggersAgain() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 1)
+
+        spy.flushScheduled()
+
+        controller.handleMessage(type: "sync", data: "{}")
+        XCTAssertEqual(spy.syncRequestedCount, 2)
+    }
+
+    // MARK: - server-event routing
+
+    func test_serverEvent_routesNameAndParams() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(
+            type: "server-event",
+            data: "{\"name\":\"order\",\"eventParams\":{\"price\":1000}}"
+        )
+
+        XCTAssertEqual(spy.eventCalls.count, 1)
+        XCTAssertEqual(spy.eventCalls.first?.0, "order")
+        XCTAssertEqual((spy.eventCalls.first?.1?["price"] as? NSNumber)?.intValue, 1000)
+    }
+
+    func test_serverEvent_malformed_doesNotTrigger() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "server-event", data: "not json")
+        XCTAssertEqual(spy.eventCalls.count, 0)
+    }
+
+    // MARK: - unknown / connected
+
+    func test_unknownType_isIgnored() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "weird", data: "")
+        XCTAssertEqual(spy.syncRequestedCount, 0)
+        XCTAssertEqual(spy.eventCalls.count, 0)
+    }
+
+    func test_connected_exitsFallbackAndMarksOpen() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 3))
+        XCTAssertEqual(controller.mode, .fallback)
+
+        // connected 메시지가 .sse 복귀 + hasReachedOpen 셋팅을 둘 다 한다.
+        controller.handleMessage(type: "connected", data: "{}")
+        XCTAssertEqual(controller.mode, .sse)
+
+        controller.handleStateChange(.reconnecting(attempt: 10))
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    // MARK: - Fallback 진입 / 비진입
+
+    func test_reconnecting_attempt3_withoutPriorOpen_entersFallback() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 1))
+        controller.handleStateChange(.reconnecting(attempt: 2))
+        controller.handleStateChange(.reconnecting(attempt: 3))
+
+        XCTAssertEqual(controller.mode, .fallback)
+    }
+
+    func test_reconnecting_below3_doesNotEnterFallback() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 1))
+        controller.handleStateChange(.reconnecting(attempt: 2))
+
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    func test_openReachedThenManyReconnects_doesNotEnterFallback() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.open)
+        controller.handleStateChange(.reconnecting(attempt: 5))
+        controller.handleStateChange(.reconnecting(attempt: 10))
+
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    func test_connectedMessage_marksOpenSoFallbackBlocked() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleMessage(type: "connected", data: "{}")
+        controller.handleStateChange(.reconnecting(attempt: 5))
+
+        XCTAssertEqual(controller.mode, .sse)
+    }
+
+    func test_fallbackEntered_thenOpenReached_returnsToSseMode() {
+        let spy = Spy()
+        let controller = makeController(spy: spy)
+
+        controller.handleStateChange(.reconnecting(attempt: 3))
+        XCTAssertEqual(controller.mode, .fallback)
+
+        controller.handleStateChange(.open)
+        XCTAssertEqual(controller.mode, .sse)
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSELineParserTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSELineParserTests.swift
@@ -1,0 +1,215 @@
+//
+//  SSELineParserTests.swift
+//  notifly-ios-sdkTests
+//
+//  WHATWG SSE 스펙 핵심 룰을 라인 단위로 검증.
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+final class SSELineParserTests: XCTestCase {
+
+    // MARK: - 기본 dispatch
+
+    func test_singleEvent_withTypeAndData_dispatchOnEmptyLine() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("event: sync"))
+        XCTAssertNil(p.feed("data: {\"ts\":1}"))
+
+        let event = p.feed("")
+        XCTAssertEqual(event, SSEEvent(id: nil, type: "sync", data: "{\"ts\":1}"))
+    }
+
+    func test_dataOnly_typeDefaultsToMessage() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("data: hello"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "hello"))
+    }
+
+    func test_emptyData_doesNotDispatch() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("event: sync"))
+        XCTAssertNil(p.feed(""))   // data 없으면 dispatch X
+    }
+
+    func test_lineWithNoColon_treatedAsFieldNameWithEmptyValue() {
+        let p = SSELineParser()
+        // "data" 라인은 field=data, value="" → 빈 data 라인 1개 누적
+        XCTAssertNil(p.feed("data"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: ""))
+    }
+
+    // MARK: - data 멀티라인
+
+    func test_multipleDataLines_joinedWithNewline() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("data: line1"))
+        XCTAssertNil(p.feed("data: line2"))
+        XCTAssertNil(p.feed("data:line3"))   // 콜론 뒤 공백 없는 케이스
+        XCTAssertEqual(
+            p.feed(""),
+            SSEEvent(id: nil, type: "message", data: "line1\nline2\nline3")
+        )
+    }
+
+    // MARK: - comment / heartbeat
+
+    func test_commentLine_ignoredAndDoesNotDispatch() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed(": heartbeat"))
+        XCTAssertNil(p.feed(":"))
+        XCTAssertNil(p.feed("data: hi"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "hi"))
+    }
+
+    // MARK: - id 처리
+
+    func test_idField_setsLastEventIdAndIsAttachedToDispatchedEvent() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("id: 42"))
+        XCTAssertNil(p.feed("data: x"))
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "42")
+        XCTAssertEqual(p.lastEventId, "42")
+    }
+
+    func test_idBufferPersists_acrossEventsWhenNotResent() {
+        let p = SSELineParser()
+        // 첫 이벤트: id 명시
+        _ = p.feed("id: 7")
+        _ = p.feed("data: a")
+        let first = p.feed("")
+        XCTAssertEqual(first?.id, "7")
+
+        // 다음 이벤트: id 라인 없음 → 직전 buffer "7" 그대로 attach
+        _ = p.feed("data: b")
+        let second = p.feed("")
+        XCTAssertEqual(second?.id, "7")
+        XCTAssertEqual(p.lastEventId, "7")
+    }
+
+    func test_idEmptyValue_resetsBufferToEmptyString() {
+        let p = SSELineParser()
+        _ = p.feed("id: 5")
+        _ = p.feed("data: a")
+        _ = p.feed("")
+        XCTAssertEqual(p.lastEventId, "5")
+
+        // id: (빈 값) → buffer 를 "" 로 갱신
+        _ = p.feed("id:")
+        _ = p.feed("data: b")
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "")
+        XCTAssertEqual(p.lastEventId, "")
+    }
+
+    func test_idWithNullByte_isIgnored() {
+        let p = SSELineParser()
+        _ = p.feed("id: ok")
+        _ = p.feed("data: a")
+        _ = p.feed("")
+        XCTAssertEqual(p.lastEventId, "ok")
+
+        // U+0000 포함 → 무시 (buffer 유지)
+        _ = p.feed("id: bad\u{0000}value")
+        _ = p.feed("data: b")
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "ok")
+        XCTAssertEqual(p.lastEventId, "ok")
+    }
+
+    // MARK: - retry / unknown field
+
+    func test_retryField_isIgnored() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("retry: 5000"))
+        XCTAssertNil(p.feed("data: x"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "x"))
+    }
+
+    func test_unknownField_isIgnored() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("custom: whatever"))
+        XCTAssertNil(p.feed("data: x"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "message", data: "x"))
+    }
+
+    // MARK: - line ending / BOM
+
+    func test_trailingCarriageReturn_isStripped() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("event: sync\r"))
+        XCTAssertNil(p.feed("data: payload\r"))
+        XCTAssertEqual(p.feed("\r"), SSEEvent(id: nil, type: "sync", data: "payload"))
+    }
+
+    func test_bomAtStart_isStripped() {
+        let p = SSELineParser()
+        XCTAssertNil(p.feed("\u{FEFF}event: sync"))
+        XCTAssertNil(p.feed("data: x"))
+        XCTAssertEqual(p.feed(""), SSEEvent(id: nil, type: "sync", data: "x"))
+    }
+
+    func test_bom_onlyStrippedFromFirstLine_preservedInDataValueAfter() {
+        let p = SSELineParser()
+        // 첫 라인의 BOM 은 제거.
+        XCTAssertNil(p.feed("\u{FEFF}event: msg"))
+        // 이후 라인의 U+FEFF 는 데이터 일부로 보존.
+        XCTAssertNil(p.feed("data: \u{FEFF}value"))
+        XCTAssertEqual(p.feed("")?.data, "\u{FEFF}value")
+    }
+
+    // MARK: - 콜론 뒤 공백 처리
+
+    func test_singleLeadingSpace_isStripped() {
+        let p = SSELineParser()
+        _ = p.feed("data: x")  // " x" 가 아니라 "x"
+        XCTAssertEqual(p.feed("")?.data, "x")
+    }
+
+    func test_multipleLeadingSpaces_onlyOneStripped() {
+        let p = SSELineParser()
+        _ = p.feed("data:  x")  // 첫 공백만 제거 → " x" 보존
+        XCTAssertEqual(p.feed("")?.data, " x")
+    }
+
+    func test_noLeadingSpace_valuePreserved() {
+        let p = SSELineParser()
+        _ = p.feed("data:x")
+        XCTAssertEqual(p.feed("")?.data, "x")
+    }
+
+    // MARK: - 통합 시나리오
+
+    func test_typicalServerSentSequence() {
+        let p = SSELineParser()
+        // connected
+        _ = p.feed(": stream opened")        // comment
+        _ = p.feed("event: connected")
+        _ = p.feed("data: {\"projectId\":\"abc\"}")
+        let connected = p.feed("")
+        XCTAssertEqual(connected?.type, "connected")
+
+        // sync (with id)
+        _ = p.feed("id: 42")
+        _ = p.feed("event: sync")
+        _ = p.feed("data: {}")
+        let sync = p.feed("")
+        XCTAssertEqual(sync, SSEEvent(id: "42", type: "sync", data: "{}"))
+
+        // heartbeat
+        _ = p.feed(": heartbeat")
+        XCTAssertNil(p.feed(""))   // dispatch 시도하지만 data 비어 dispatch 안 됨
+
+        // server-event with multiline data
+        _ = p.feed("id: 43")
+        _ = p.feed("event: server-event")
+        _ = p.feed("data: {\"name\":\"order_completed\",")
+        _ = p.feed("data:  \"eventParams\":{}}")
+        let event = p.feed("")
+        XCTAssertEqual(event?.id, "43")
+        XCTAssertEqual(event?.type, "server-event")
+        XCTAssertEqual(event?.data, "{\"name\":\"order_completed\",\n \"eventParams\":{}}")
+    }
+}

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEMessageTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/SSE/SSEMessageTests.swift
@@ -1,0 +1,116 @@
+//
+//  SSEMessageTests.swift
+//  notifly-ios-sdkTests
+//
+
+import XCTest
+@testable import notifly_ios_sdk
+
+final class SSEMessageTests: XCTestCase {
+
+    // MARK: - simple types
+
+    func test_connected_dataIgnored() {
+        if case .connected = SSEMessage.decode(type: "connected", data: "{\"projectId\":\"x\"}") {
+            return
+        }
+        XCTFail("expected .connected")
+    }
+
+    func test_sync_dataIgnored() {
+        if case .sync = SSEMessage.decode(type: "sync", data: "{\"ts\":1}") {
+            return
+        }
+        XCTFail("expected .sync")
+    }
+
+    func test_ttlExpired() {
+        if case .ttlExpired = SSEMessage.decode(type: "ttl-expired", data: "{\"reason\":\"connection-ttl\"}") {
+            return
+        }
+        XCTFail("expected .ttlExpired")
+    }
+
+    func test_unknown_type() {
+        if case .unknown(let raw) = SSEMessage.decode(type: "weird", data: "") {
+            XCTAssertEqual(raw, "weird")
+        } else {
+            XCTFail("expected .unknown")
+        }
+    }
+
+    // MARK: - server-event
+
+    func test_serverEvent_withNameAndEventParams() {
+        let data = "{\"name\":\"order_completed\",\"eventParams\":{\"price\":1000}}"
+        if case .event(let name, let params) = SSEMessage.decode(type: "server-event", data: data) {
+            XCTAssertEqual(name, "order_completed")
+            XCTAssertEqual(params?["price"] as? Int, 1000)
+        } else {
+            XCTFail("expected .event")
+        }
+    }
+
+    func test_serverEvent_withoutEventParams() {
+        let data = "{\"name\":\"x\"}"
+        if case .event(let name, let params) = SSEMessage.decode(type: "server-event", data: data) {
+            XCTAssertEqual(name, "x")
+            XCTAssertNil(params)
+        } else {
+            XCTFail("expected .event")
+        }
+    }
+
+    func test_serverEvent_missingName_isMalformed() {
+        let data = "{\"eventParams\":{}}"
+        if case .malformed(let raw) = SSEMessage.decode(type: "server-event", data: data) {
+            XCTAssertEqual(raw, "server-event")
+        } else {
+            XCTFail("expected .malformed")
+        }
+    }
+
+    func test_serverEvent_invalidJSON_isMalformed() {
+        if case .malformed = SSEMessage.decode(type: "server-event", data: "not json") {
+            return
+        }
+        XCTFail("expected .malformed")
+    }
+
+    // MARK: - shutdown
+
+    func test_shutdown_withReconnectInMs() {
+        let data = "{\"reason\":\"deployment\",\"reconnectInMs\":1500}"
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: data) {
+            XCTAssertEqual(ms, 1500)
+        } else {
+            XCTFail("expected .shutdown(1500)")
+        }
+    }
+
+    func test_shutdown_withoutReconnectInMs_defaultsToZero() {
+        let data = "{\"reason\":\"x\"}"
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: data) {
+            XCTAssertEqual(ms, 0)
+        } else {
+            XCTFail("expected .shutdown(0)")
+        }
+    }
+
+    func test_shutdown_invalidJSON_defaultsToZero() {
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: "garbage") {
+            XCTAssertEqual(ms, 0)
+        } else {
+            XCTFail("expected .shutdown(0)")
+        }
+    }
+
+    func test_shutdown_negativeReconnectInMs_clampedToZero() {
+        let data = "{\"reconnectInMs\":-100}"
+        if case .shutdown(let ms) = SSEMessage.decode(type: "shutdown", data: data) {
+            XCTAssertEqual(ms, 0)
+        } else {
+            XCTFail("expected .shutdown(0)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- iOS SDK 에 SSE 채널 도입으로 캠페인 데이터를 실시간 동기화. 서버에서 캠페인 상태가 변경되면 SDK 가 즉시 local data 를 refresh.
- Reconnect 시 \`Last-Event-ID\` 헤더로 disconnect 중 누락된 popup entry 를 서버가 replay 해서 복구.
- SSE 가 OPEN 상태에 도달 못하면 기존 event-driven sync 로 자동 fallback.
- Reconnect backoff 를 full jitter (100ms~10s) 로 단순화, 서버 측 동시 끊김 (rolling deploy 등) 의 thundering herd 완화.
- SSE 로그를 운영에 필요한 4가지로 축소: \`connected\` / \`disconnected\` / \`sync received\` + 오류 로그.
- 버전: 2.4.0 → **2.5.0**.

## Test plan

- [x] \`xcodebuild test\` 통과 (SSE 단위 테스트 + 통합 테스트 포함)
- [x] Stage 환경에서 SSE 연결 + sync 수신 시 popup 즉시 표시 확인
- [x] BG → FG 전환 시 reconnect + Last-Event-ID 기반 popup 복구 확인
- [x] Reconnect 폭주 시나리오에서 backoff 분포 확인
- [x] Fallback 모드 전환 (SSE 도달 못하는 환경) 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 캠페인 데이터 동기화를 위한 SSE 기반 스트리밍 연결 지원 추가
  * 재연결 시 Last-Event-ID로 오프라인 중 누락된 항목 재전송 지원
  * 앱 포그라운드/백그라운드 연동으로 SSE 자동 시작/중단 지원

* **개선사항**
  * 재연결 백오프를 full jitter(100ms–10s)로 조정
  * SSE 연결 실패 시 기존 이벤트 기반 동기화로 자동 폴백
  * 로깅을 핵심 이벤트 수준으로 축소

* **문서**
  * CHANGELOG에 2.5.0 릴리스 및 SSE 내용 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->