### PR TITLE
fix: APNs→FCM token acquisition ordering race on cold start (2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2026-06-10
+
+### Fixed
+
+- **APNs → FCM token acquisition ordering race on cold start.** The APNs token was assigned to Firebase Messaging on an async dispatch while the FCM token request was issued synchronously right after, so `Messaging.token(completion:)` could run before the APNs token was associated. This could register a stale/unassociated FCM token and drive repeated token re-acquisition. The APNs token assignment and the FCM token request now run within the same main-queue block, so the assignment is guaranteed to happen first (matching the ordering already used in the retry path).
+
 ## [2.5.0] - 2026-06-01
 
 ### Added

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Notifications/NotificationsManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Notifications/NotificationsManager.swift
@@ -144,11 +144,17 @@ class NotificationsManager: NSObject {
             ])
         }
 
-        DispatchQueue.main.async {
+        // Assign the APNs token to Firebase and request the FCM token within the same
+        // main-queue block so the assignment is guaranteed to happen before
+        // Messaging.token(completion:) runs. Previously the assignment was dispatched
+        // async while requestFCMTokenWithRetry() ran synchronously outside the block,
+        // so the FCM token could be requested before the APNs token was associated —
+        // yielding a stale/unassociated token on cold start and driving repeated token
+        // re-acquisition. (This mirrors the ordering already used in the retry path.)
+        DispatchQueue.main.async { [weak self] in
             Messaging.messaging().apnsToken = deviceToken
+            self?.requestFCMTokenWithRetry()
         }
-
-        requestFCMTokenWithRetry()
     }
 
     func registerFCMToken(token: String) {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "2.5.0"
+    static let sdkVersion: String = "2.5.1"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '2.5.0'
+  s.version          = '2.5.1'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 2.5.0
+  NOTIFLY iOS SDK : 2.5.1
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'

--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk_push_extension'
-  s.version          = '2.5.0'
+  s.version          = '2.5.1'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS Push Extension SDK : 2.5.0
+  NOTIFLY iOS Push Extension SDK : 2.5.1
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary

Fixes a cold-start race in `NotificationsManager` where the FCM token could be requested **before** the APNs token was associated with Firebase Messaging, causing a stale/unassociated FCM token to be registered and driving repeated token re-acquisition.

## Root cause

In `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`:

```swift
DispatchQueue.main.async {
    Messaging.messaging().apnsToken = deviceToken   // deferred to next runloop
}
requestFCMTokenWithRetry()                          // runs now → Messaging.token(completion:)
```

`requestFCMTokenWithRetry()` calls `Messaging.token(completion:)` synchronously, while the APNs-token assignment is deferred to the next runloop. So on cold start the FCM token is fetched before the APNs token is set, which can return a stale/unassociated token. Combined with the event-driven re-acquisition path (every tracked event reads `deviceTokenPub`, which restarts acquisition when the token is in a failed state), this can surface as repeated `device_token` changes and FCM `UNREGISTERED` (404) on delivery.

This ordering changed in 2.3.0 (the assignment was synchronous in 2.1.0).

## Fix

Assign the APNs token to Firebase **synchronously** before requesting the FCM token, restoring a guaranteed happens-before:

```swift
Messaging.messaging().apnsToken = deviceToken
requestFCMTokenWithRetry()
```

## Validation

Reproduced on an iOS Simulator with the example app (NSLog instrumentation in `didRegister`):

- **Before (2.3.0 / async):** `calling Messaging.messaging().token` logged **before** `assigning Messaging.apnsToken` → race.
- **After (sync):** `assigning Messaging.apnsToken` logged **before** `calling Messaging.messaging().token` → ordering safe.

## Version

Bumps `notifly_sdk` / `notifly_sdk_push_extension` and `NotiflyConstant.sdkVersion` to **2.5.1**, with a CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS 푸시 콜드 스타트 시 APNs→FCM 토큰 매핑의 타이밍 문제를 수정해, FCM에 비연결·스테일 토큰이 등록되거나 반복 재획득이 발생하는 현상을 방지했습니다.

* **Documentation**
  * 2.5.1 릴리스의 수정 내역을 CHANGELOG에 반영·문서화했습니다.

* **Chores**
  * SDK 및 배포 메타데이터 버전을 2.5.1로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->