### PR TITLE
feat(push): 광고 푸시 수신거부 액션 지원

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-06-15
+
+### Added
+
+- **Ad push opt-out ("수신거부") action.** Push notifications carrying an `unsubscribe_url` custom-data field are treated as ad pushes and now expose a "수신거부" action on long-press; tapping it opens the `unsubscribe_url` (custom scheme deep link or web page). The SDK registers the `NOTIFLY_AD` notification category — merged with any categories the host app already registered — and handles the action tap. The cold-start case is covered: the tapped action identifier is cached so that, when the app is launched from a kill state by the opt-out tap, it navigates to the unsubscribe destination rather than the notification's content URL.
+  - Requires the server to deliver ad pushes with `aps.category = "NOTIFLY_AD"` (alongside the `unsubscribe_url` custom data).
+
 ## [2.5.1] - 2026-06-10
 
 ### Fixed

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Notifications/NotificationsManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Notifications/NotificationsManager.swift
@@ -489,6 +489,33 @@ class NotificationsManager: NSObject {
 
     private func setup() {
         startTokenAcquisition()
+        registerAdPushCategory()
+    }
+
+    /// 광고 푸시 수신거부 액션 카테고리를 등록한다.
+    /// 앱이 이미 등록한 다른 카테고리를 덮어쓰지 않도록 기존 카테고리와 병합한다.
+    private func registerAdPushCategory() {
+        let center = UNUserNotificationCenter.current()
+        center.getNotificationCategories { existing in
+            guard
+                !existing.contains(where: {
+                    $0.identifier == NotiflyConstant.AdPush.categoryIdentifier
+                })
+            else {
+                return
+            }
+
+            let unsubscribeAction = UNNotificationAction(
+                identifier: NotiflyConstant.AdPush.unsubscribeActionIdentifier,
+                title: NotiflyConstant.AdPush.unsubscribeActionTitle,
+                options: [.foreground])
+            let adCategory = UNNotificationCategory(
+                identifier: NotiflyConstant.AdPush.categoryIdentifier,
+                actions: [unsubscribeAction],
+                intentIdentifiers: [],
+                options: [])
+            center.setNotificationCategories(existing.union([adCategory]))
+        }
     }
 }
 
@@ -501,6 +528,17 @@ extension NotificationsManager: UNUserNotificationCenterDelegate {
         _: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) {
+        // 광고 푸시의 "수신거부" 액션을 탭한 경우: unsubscribe_url 스킴/URL로 이동.
+        if response.actionIdentifier == NotiflyConstant.AdPush.unsubscribeActionIdentifier {
+            if let urlString = response.notification.request.content.userInfo[
+                NotiflyConstant.AdPush.unsubscribeUrlKey] as? String,
+                let url = URL(string: urlString)
+            {
+                UIApplication.shared.open(url, options: [:])
+            }
+            return
+        }
+
         if let pushData = response.notification.request.content.userInfo as [AnyHashable: Any]?,
             let clickStatus = UIApplication.shared.applicationState == .active
                 ? "foreground" : "background"

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly+PublicAPI.swift
@@ -46,23 +46,35 @@ import UIKit
         }
 
         if let pushData = Notifly.coldStartNotificationData {
-            let clickStatus = "background"
-            if let urlString = pushData["url"] as? String,
-                let url = URL(string: urlString)
+            if Notifly.coldStartNotificationActionIdentifier
+                == NotiflyConstant.AdPush.unsubscribeActionIdentifier
             {
-                UIApplication.shared.open(url, options: [:]) { _ in
+                // 콜드스타트에서 "수신거부" 액션이 탭된 경우: 본문 url 이 아니라 unsubscribe_url 로 이동.
+                if let urlString = pushData[NotiflyConstant.AdPush.unsubscribeUrlKey] as? String,
+                    let url = URL(string: urlString)
+                {
+                    UIApplication.shared.open(url, options: [:])
+                }
+            } else {
+                let clickStatus = "background"
+                if let urlString = pushData["url"] as? String,
+                    let url = URL(string: urlString)
+                {
+                    UIApplication.shared.open(url, options: [:]) { _ in
+                        main.trackingManager.trackPushClickInternalEvent(
+                            pushData: pushData,
+                            clickStatus: clickStatus
+                        )
+                    }
+                } else {
                     main.trackingManager.trackPushClickInternalEvent(
                         pushData: pushData,
                         clickStatus: clickStatus
                     )
                 }
-            } else {
-                main.trackingManager.trackPushClickInternalEvent(
-                    pushData: pushData,
-                    clickStatus: clickStatus
-                )
             }
             Notifly.coldStartNotificationData = nil
+            Notifly.coldStartNotificationActionIdentifier = nil
         }
 
         // NotificationsManager now handles all token acquisition logic
@@ -131,6 +143,7 @@ import UIKit
             }
             guard let main = try? main else {
                 Notifly.coldStartNotificationData = pushData
+                Notifly.coldStartNotificationActionIdentifier = response.actionIdentifier
                 return
             }
 

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Notifly/Notifly.swift
@@ -22,6 +22,7 @@ import UIKit
     }
 
     static var coldStartNotificationData: [AnyHashable: Any]?
+    static var coldStartNotificationActionIdentifier: String?
     static var inAppMessageDisabled: Bool = false
 
     private let cancellablesAccessQueue = DispatchQueue(label: "com.notifly.manager.access.queue")

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "2.5.1"
+    static let sdkVersion: String = "2.6.0"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -10,6 +10,17 @@ enum NotiflySdkConfig {
 enum NotiflyConstant {
     static let iosPlatform: String = "ios"
     static let projectIdRegex: String = "^[0-9a-fA-F]{32}$"
+
+    /// 광고 푸시 수신거부 액션 관련 상수.
+    /// 푸시 payload(커스텀 데이터)에 `unsubscribe_url`이 있으면 광고 푸시로 간주하고,
+    /// 길게 눌렀을 때 "수신거부" 액션이 노출되도록 한다.
+    enum AdPush {
+        static let categoryIdentifier = "NOTIFLY_AD"
+        static let unsubscribeActionIdentifier = "NOTIFLY_UNSUBSCRIBE"
+        static let unsubscribeUrlKey = "unsubscribe_url"
+        static let unsubscribeActionTitle = "수신거부"
+    }
+
     enum EndPoint {
         static let trackEventEndPoint =
             "https://e.notifly.tech/records"

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '2.5.1'
+  s.version          = '2.6.0'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC

--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk_push_extension'
-  s.version          = '2.5.1'
+  s.version          = '2.6.0'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
## 개요
광고 푸시 수신거부(opt-out) 액션을 SDK에서 지원합니다. 사용자가 알림을 **길게 누르면 "수신거부" 액션**이 노출되고, 탭하면 `unsubscribe_url`로 이동합니다.

## 변경 사항 (SDK)
- **`Constants.swift`**: `NotiflyConstant.AdPush` 상수 추가 (카테고리/액션 ID, `unsubscribe_url` 키, 액션 라벨 "수신거부")
- **`NotificationsManager.swift`**: 초기화 시 `NOTIFLY_AD` 카테고리 등록(기존 카테고리와 **병합**) + warm 상태 "수신거부" 탭 시 `unsubscribe_url` 이동
- **`Notifly.swift` / `Notifly+PublicAPI.swift`**: **콜드스타트** 보강 — 앱 종료 상태에서 수신거부를 탭한 경우, 액션 식별자를 함께 캐싱해 init 후 처리 시 본문 `url`이 아니라 `unsubscribe_url`로 이동

> NSE는 건드리지 않습니다. 앱이 Notification Service Extension을 붙이지 않은 경우에도 동작하도록, 카테고리 부착은 클라이언트(NSE) 대신 **서버 payload**에서 처리합니다.

## 서버 의존 (필수)
광고 푸시 APNs payload에 다음이 함께 내려와야 합니다:
- `aps.category = "NOTIFLY_AD"` ← 액션 노출 트리거 (서버 설정)
- `unsubscribe_url` (커스텀 데이터) ← 탭 시 이동 목적지

## 역할 분담
| 단계 | 담당 |
|---|---|
| 카테고리(액션) 정의·등록 | **SDK** |
| 알림에 카테고리 부착 | **서버** (`aps.category`) |
| 수신거부 탭 → 이동 (warm/cold 모두) | **SDK** |

## 참고 / 후속
- "수신거부" 문구 한국어 하드코딩 (i18n 미적용)
- 수신거부 전용 트래킹 이벤트 없음 (opt-out 발생률 측정하려면 추가 필요 — 콜드스타트 소비부에서 `main` 사용 가능)
- 카테고리 등록은 init 1회 — 앱이 init 이후 자체 카테고리를 set 하면 덮어쓸 수 있음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 광고 푸시 알림에 ‘수신거부’ 액션 버튼을 추가해, 알림에서 바로 수신거부 URL로 이동할 수 있도록 지원합니다.
  * 수신거부 액션을 탭하면 `unsubscribe_url`로 이동하며, 콜드스타트 상태에서도 해당 액션을 인식해 목적지로 내비게이션됩니다.
* **Chores**
  * iOS SDK 및 푸시 익스텐션 버전을 2.6.0으로 업데이트하고 릴리스 노트를 반영했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->