### PR TITLE
fix: guard session_start by active app state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1] - 2026-07-13
+
+### Fixed
+
+- Prevent `session_start` internal events from being tracked unless the host app is in the foreground active state. This avoids recording background remote-notification/fetch process wakes as user-visible sessions.
+
 ## [2.6.0] - 2026-06-15
 
 ### Added

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
@@ -19,9 +19,6 @@ class TrackingManager {
     private var cancellables = Set<AnyCancellable>()
     private let cancellablesAccessQueue = DispatchQueue(
         label: "TrackingManagerCancellablesAccessQueue")
-    private var isSessionStartPendingUntilActive = false
-    private let sessionStartStateQueue = DispatchQueue(
-        label: "TrackingManagerSessionStartStateQueue")
 
     init(projectId: String) {
         self.projectId = projectId
@@ -66,12 +63,7 @@ class TrackingManager {
 
     func trackSessionStartInternalEvent() {
         guard Self.canTrackSessionStartInCurrentApplicationState() else {
-            scheduleSessionStartWhenApplicationBecomesActive()
             return
-        }
-
-        sessionStartStateQueue.sync {
-            isSessionStartPendingUntilActive = false
         }
 
         UNUserNotificationCenter.current().getNotificationSettings { settings in
@@ -102,53 +94,6 @@ class TrackingManager {
                 lockAcquired: true
             )
         }
-    }
-
-    private func scheduleSessionStartWhenApplicationBecomesActive() {
-        let shouldSchedule = sessionStartStateQueue.sync { () -> Bool in
-            guard !isSessionStartPendingUntilActive else {
-                return false
-            }
-
-            isSessionStartPendingUntilActive = true
-            return true
-        }
-
-        guard shouldSchedule else {
-            return
-        }
-
-        let cancellable = NotificationCenter.default.publisher(
-            for: UIApplication.didBecomeActiveNotification
-        )
-        .prefix(1)
-        .sink { [weak self] _ in
-            self?.trackPendingSessionStartIfNeeded()
-        }
-
-        storeCanellables(cancellable: cancellable)
-
-        if Self.canTrackSessionStartInCurrentApplicationState() {
-            cancellable.cancel()
-            trackPendingSessionStartIfNeeded()
-        }
-    }
-
-    private func trackPendingSessionStartIfNeeded() {
-        let shouldTrack = sessionStartStateQueue.sync { () -> Bool in
-            guard isSessionStartPendingUntilActive else {
-                return false
-            }
-
-            isSessionStartPendingUntilActive = false
-            return true
-        }
-
-        guard shouldTrack else {
-            return
-        }
-
-        trackSessionStartInternalEvent()
     }
 
     func trackSetDevicePropertiesInternalEvent(properties: [String: Any]) {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
@@ -123,10 +123,32 @@ class TrackingManager {
         )
         .prefix(1)
         .sink { [weak self] _ in
-            self?.trackSessionStartInternalEvent()
+            self?.trackPendingSessionStartIfNeeded()
         }
 
         storeCanellables(cancellable: cancellable)
+
+        if Self.canTrackSessionStartInCurrentApplicationState() {
+            cancellable.cancel()
+            trackPendingSessionStartIfNeeded()
+        }
+    }
+
+    private func trackPendingSessionStartIfNeeded() {
+        let shouldTrack = sessionStartStateQueue.sync { () -> Bool in
+            guard isSessionStartPendingUntilActive else {
+                return false
+            }
+
+            isSessionStartPendingUntilActive = false
+            return true
+        }
+
+        guard shouldTrack else {
+            return
+        }
+
+        trackSessionStartInternalEvent()
     }
 
     func trackSetDevicePropertiesInternalEvent(properties: [String: Any]) {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/Infrastructures/Tracking/TrackingManager.swift
@@ -19,6 +19,9 @@ class TrackingManager {
     private var cancellables = Set<AnyCancellable>()
     private let cancellablesAccessQueue = DispatchQueue(
         label: "TrackingManagerCancellablesAccessQueue")
+    private var isSessionStartPendingUntilActive = false
+    private let sessionStartStateQueue = DispatchQueue(
+        label: "TrackingManagerSessionStartStateQueue")
 
     init(projectId: String) {
         self.projectId = projectId
@@ -47,7 +50,30 @@ class TrackingManager {
         }
     }
 
+    static func canTrackSessionStart(applicationState: UIApplication.State) -> Bool {
+        applicationState == .active
+    }
+
+    private static func canTrackSessionStartInCurrentApplicationState() -> Bool {
+        if Thread.isMainThread {
+            return canTrackSessionStart(applicationState: UIApplication.shared.applicationState)
+        }
+
+        return DispatchQueue.main.sync {
+            canTrackSessionStart(applicationState: UIApplication.shared.applicationState)
+        }
+    }
+
     func trackSessionStartInternalEvent() {
+        guard Self.canTrackSessionStartInCurrentApplicationState() else {
+            scheduleSessionStartWhenApplicationBecomesActive()
+            return
+        }
+
+        sessionStartStateQueue.sync {
+            isSessionStartPendingUntilActive = false
+        }
+
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             var authStatus = 0
             switch settings.authorizationStatus {
@@ -76,6 +102,31 @@ class TrackingManager {
                 lockAcquired: true
             )
         }
+    }
+
+    private func scheduleSessionStartWhenApplicationBecomesActive() {
+        let shouldSchedule = sessionStartStateQueue.sync { () -> Bool in
+            guard !isSessionStartPendingUntilActive else {
+                return false
+            }
+
+            isSessionStartPendingUntilActive = true
+            return true
+        }
+
+        guard shouldSchedule else {
+            return
+        }
+
+        let cancellable = NotificationCenter.default.publisher(
+            for: UIApplication.didBecomeActiveNotification
+        )
+        .prefix(1)
+        .sink { [weak self] _ in
+            self?.trackSessionStartInternalEvent()
+        }
+
+        storeCanellables(cancellable: cancellable)
     }
 
     func trackSetDevicePropertiesInternalEvent(properties: [String: Any]) {

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdk/SourceCodes/NotiflyUtil/Constants.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum NotiflySdkConfig {
-    static let sdkVersion: String = "2.6.0"
+    static let sdkVersion: String = "2.6.1"
     static var sdkWrapperVersion: String?
     static let sdkType: String = "native"
     static var sdkWrapperType: SdkWrapperType?

--- a/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/notifly_ios_sdkTests.swift
+++ b/Sources/Notifly/notifly-ios-sdk/notifly-ios-sdkTests/notifly_ios_sdkTests.swift
@@ -5,32 +5,20 @@
 //  Created by Juyong Kim on 4/15/23.
 //
 
+import UIKit
 import XCTest
 @testable import notifly_ios_sdk
 
 class notifly_ios_sdkTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func testSessionStartIsAllowedOnlyWhenApplicationIsActive() {
+        XCTAssertTrue(
+            TrackingManager.canTrackSessionStart(applicationState: .active)
+        )
+        XCTAssertFalse(
+            TrackingManager.canTrackSessionStart(applicationState: .inactive)
+        )
+        XCTAssertFalse(
+            TrackingManager.canTrackSessionStart(applicationState: .background)
+        )
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/notifly_sdk.podspec
+++ b/notifly_sdk.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk'
-  s.version          = '2.6.0'
+  s.version          = '2.6.1'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS SDK : 2.5.1
+  NOTIFLY iOS SDK : 2.6.1
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'

--- a/notifly_sdk_push_extension.podspec
+++ b/notifly_sdk_push_extension.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'notifly_sdk_push_extension'
-  s.version          = '2.6.0'
+  s.version          = '2.6.1'
   s.summary          = 'Notifly iOS SDK.'
 
   s.description      = <<-DESC
-  NOTIFLY iOS Push Extension SDK : 2.5.1
+  NOTIFLY iOS Push Extension SDK : 2.6.1
   DESC
 
   s.homepage         = 'https://github.com/team-michael/notifly-ios-sdk'


### PR DESCRIPTION
## Summary
- Guard `session_start` internal tracking so it only fires when the app is in `.active` foreground state
- Drop `session_start` attempts made while the app is `.inactive` or `.background`, including background remote-notification/fetch process wakes
- Bump SDK versions to 2.6.1 and update changelog

## Test Plan
- `git diff --check`
- Static source verification for active-state guard
- Not run: XCTest/xcodebuild unavailable on this Linux host (`xcodebuild` and `swift` are not installed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 앱이 전면 활성 상태일 때만 세션 시작 이벤트가 추적되도록 개선했습니다.
  * 백그라운드 알림이나 백그라운드 작업으로 인한 사용자 비가시 세션 기록을 방지했습니다.

* **테스트**
  * 앱 상태별 세션 시작 이벤트 추적 조건을 검증하는 테스트를 추가했습니다.

* **릴리스**
  * SDK 및 푸시 확장 SDK 버전을 2.6.1로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->